### PR TITLE
Remove AMQP from list of default plugins

### DIFF
--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -37,7 +37,7 @@ CORS_ORIGINS = [
 CORS_SUPPORTS_CREDENTIALS = AUTH_REQUIRED
 
 # Plug-ins
-PLUGINS = ['reject', 'amqp']
+PLUGINS = ['reject']
 # PLUGINS = ['amqp', 'enhance', 'logstash', 'normalise', 'reject', 'sns']
 
 # AMQP Credentials


### PR DESCRIPTION
Directly integrating third-party apps using specific plugins is the
preferred approach now so do not enable the AMQP plugin by default.