### PR TITLE
Suppress alerts based on blackout rules to support maintenance mode

### DIFF
--- a/alerta/app/database.py
+++ b/alerta/app/database.py
@@ -930,14 +930,18 @@ class Mongo(object):
         elif service:
             data["priority"] = 3
             data["service"] = service
-        elif resource and event:
+        elif event and not resource:
             data["priority"] = 4
             data["event"] = event
         elif group:
             data["priority"] = 5
             data["group"] = group
-        elif tags:
+        elif resource and event:
             data["priority"] = 6
+            data["resource"] = resource
+            data["event"] = event
+        elif tags:
+            data["priority"] = 7
             data["tags"] = tags
 
         return self._db.blackouts.insert_one(data).inserted_id

--- a/alerta/app/database.py
+++ b/alerta/app/database.py
@@ -867,7 +867,7 @@ class Mongo(object):
             {
                 "environment": alert.environment,
                 "resource": {'$exists': False},
-                "service": alert.service,
+                "service": {"$not": {"$elemMatch": {"$nin": alert.service}}},
                 "event": {'$exists': False},
                 "group": {'$exists': False},
                 "tags": {'$exists': False}

--- a/alerta/app/database.py
+++ b/alerta/app/database.py
@@ -911,17 +911,21 @@ class Mongo(object):
 
         return False
 
-    def create_blackout(self, environment, resource=None, service=None, event=None, group=None, tags=None, start=None, duration=None):
+    def create_blackout(self, environment, resource=None, service=None, event=None, group=None, tags=None, start=None, end=None, duration=None):
 
         start = start or datetime.datetime.utcnow()
-        duration = duration or app.config['BLACKOUT_DURATION']
+        if end:
+            duration = int((end - start).total_seconds())
+        else:
+            duration = duration or app.config['BLACKOUT_DURATION']
+            end = start + datetime.timedelta(seconds=duration)
 
         data = {
             "_id": str(uuid4()),
             "priority": 1,
             "environment": environment,
             "startTime": start,
-            "endTime": start + datetime.timedelta(seconds=duration),
+            "endTime": end,
             "duration": duration
         }
         if resource and not event:

--- a/alerta/app/utils.py
+++ b/alerta/app/utils.py
@@ -202,6 +202,9 @@ def process_alert(incomingAlert):
         if not incomingAlert:
             raise SyntaxError('Plug-in pre-receive hook did not return modified alert')
 
+    if db.is_blackout_period(incomingAlert):
+        raise RuntimeWarning('Suppressed during blackout period')
+
     try:
         if db.is_duplicate(incomingAlert):
             started = duplicate_timer.start_timer()

--- a/alerta/app/views.py
+++ b/alerta/app/views.py
@@ -498,12 +498,15 @@ def create_blackout():
     resource = request.json.get("resource", None)
     service = request.json.get("service", None)
     event = request.json.get("event", None)
-    groups = request.json.get("groups", None)
+    group = request.json.get("group", None)
     tags = request.json.get("tags", None)
-    duration = request.json.get("service", 60)
+    start_time = request.json.get("startTime", None)
+    if start_time:
+        start_time = datetime.datetime.strptime(start_time, '%Y-%m-%dT%H:%M:%S.%fZ')
+    duration = request.json.get("duration", None)
 
     try:
-        blackout = db.create_blackout(environment, resource, service, event, groups, tags, duration)
+        blackout = db.create_blackout(environment, resource, service, event, group, tags, start_time, duration)
     except Exception as e:
         return jsonify(status="error", message=str(e)), 500
 

--- a/alerta/app/views.py
+++ b/alerta/app/views.py
@@ -501,12 +501,16 @@ def create_blackout():
     group = request.json.get("group", None)
     tags = request.json.get("tags", None)
     start_time = request.json.get("startTime", None)
-    if start_time:
-        start_time = datetime.datetime.strptime(start_time, '%Y-%m-%dT%H:%M:%S.%fZ')
+    end_time = request.json.get("endTime", None)
     duration = request.json.get("duration", None)
 
+    if start_time:
+        start_time = datetime.datetime.strptime(start_time, '%Y-%m-%dT%H:%M:%S.%fZ')
+    if end_time:
+        end_time = datetime.datetime.strptime(end_time, '%Y-%m-%dT%H:%M:%S.%fZ')
+
     try:
-        blackout = db.create_blackout(environment, resource, service, event, group, tags, start_time, duration)
+        blackout = db.create_blackout(environment, resource, service, event, group, tags, start_time, end_time, duration)
     except Exception as e:
         return jsonify(status="error", message=str(e)), 500
 

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -39,7 +39,7 @@ CORS_ORIGINS = [
 CORS_SUPPORTS_CREDENTIALS = AUTH_REQUIRED
 
 # Plug-ins
-PLUGINS = ['reject']
+PLUGINS = ['reject', 'blackout']
 # PLUGINS = ['amqp', 'enhance', 'logstash', 'normalise', 'reject', 'sns']
 
 ORIGIN_BLACKLIST = ['foo/bar$', '.*/qux']  # reject all foo alerts from bar, and everything from qux

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -38,8 +38,10 @@ CORS_ORIGINS = [
 ]
 CORS_SUPPORTS_CREDENTIALS = AUTH_REQUIRED
 
+BLACKOUT_DURATION = 3600  # default period = 1 hour
+
 # Plug-ins
-PLUGINS = ['reject', 'blackout']
+PLUGINS = ['reject']
 # PLUGINS = ['amqp', 'enhance', 'logstash', 'normalise', 'reject', 'sns']
 
 ORIGIN_BLACKLIST = ['foo/bar$', '.*/qux']  # reject all foo alerts from bar, and everything from qux


### PR DESCRIPTION
An alert that is received during a blackout period is accepted by Alerta and a `202 Accepted` status code returned. However, it will not be added to the Alerta database.

Blackout rules can be any of:
  * an entire environment eg. `environment=Production`
  * a particular resource eg. `resource=host55`
  * an entire service eg. `service=Web`
  * every occurrence of a specific event eg. `event=DiskFull`
  * a group of events eg. `group=Syslog`
  * a specific event for a resource eg. `resource=host55` and `event=DiskFull`
  * all events that have a specific set of tags eg. `tags=[ blackout, london ]`

Note: an `environment` must be defined for a blackout rule.

Requested by #111 