### PR TITLE
Requirements file needs to point to setup.py so plugins get installed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,2 @@
-alerta
-Flask
-Flask-Cors
-pymongo>=3.0
-kombu
-boto
-argparse
-requests
-requests-oauthlib
-pytz
-PyJWT
-cffi
-bcrypt
 gunicorn
+-e .


### PR DESCRIPTION
Having a requirements.txt file that didn't point to setup.py meant that plugins weren't being installed on Heroku.
