### PR TITLE
Admin users is independent feature of customer views

### DIFF
--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -24,14 +24,8 @@ MONGO_USERNAME = 'alerta'
 MONGO_PASSWORD = None
 
 AUTH_REQUIRED = False
+ADMIN_USERS = []
 CUSTOMER_VIEWS = False
-
-ADMIN_USERS = [
-    'first.last@gmail.com',  # google
-    '@twitter',              # twitter
-    'octocat',               # github/gitlab
-    'username'               # basic
-]
 
 OAUTH2_CLIENT_ID = 'INSERT-OAUTH2-CLIENT-ID-HERE'  # Google or GitHub OAuth2 client ID and secret
 OAUTH2_CLIENT_SECRET = 'INSERT-OAUTH2-CLIENT-SECRET-HERE'


### PR DESCRIPTION
It is now possible to have two tiers of user (`admin` and normal `user`) that allows for greater access control.

This is enabled by setting `ADMIN_USERS` to an email address or Github/GitLab login id in `alertad.conf` so that there is always at least one admin user.