### PR TITLE
Add support for customer views to basic auth logins

### DIFF
--- a/alerta/app/__init__.py
+++ b/alerta/app/__init__.py
@@ -48,6 +48,15 @@ else:
     app.logger.addHandler(stderr_handler)
     app.logger.setLevel(logging.INFO)
 
+# Runtime config check
+if app.config['CUSTOMER_VIEWS'] and not app.config['AUTH_REQUIRED']:
+    app.logger.error('To use customer views you must enable authentication')
+    sys.exit(1)
+
+if app.config['CUSTOMER_VIEWS'] and not app.config['ADMIN_USERS']:
+    app.logger.error('Customer views is enabled but there are no admin users')
+    sys.exit(1)
+
 cors = CORS(app)
 
 from alerta.app.database import Mongo

--- a/alerta/app/auth.py
+++ b/alerta/app/auth.py
@@ -169,7 +169,20 @@ def login():
         return jsonify(status="error", message="User %s is not authorized" % email), 401, \
             {'WWW-Authenticate': 'Basic realm="%s"' % BASIC_AUTH_REALM}
 
-    token = create_token(user['id'], user['name'], email, provider='basic')
+    if email in app.config['ADMIN_USERS']:
+        role = 'admin'
+    else:
+        role = 'user'
+
+    if role == 'admin':
+        customer = None
+    else:
+        customer = db.get_customer_by_reference(email)
+        print customer
+        if not customer:
+            return jsonify(status="error", message="No customer lookup defined for user %s" % email), 403
+
+    token = create_token(user['id'], user['name'], email, provider='basic', customer=customer, role=role)
     return jsonify(token=token)
 
 
@@ -179,13 +192,12 @@ def signup():
 
     if request.json and 'name' in request.json:
         name = request.json["name"]
-        login = request.json["email"]
+        email = request.json["email"]
         password = request.json["password"]
         provider = request.json.get("provider", "basic")
-        customer = request.json.get("customer", None)
         text = request.json.get("text", "")
         try:
-            user_id = db.save_user(str(uuid4()), name, login, password, provider, customer, text)
+            user_id = db.save_user(str(uuid4()), name, email, password, provider, text)
         except Exception as e:
             return jsonify(status="error", message=str(e)), 500
     else:
@@ -194,9 +206,22 @@ def signup():
     if user_id:
         user = db.get_user(user_id)
     else:
-        user = db.get_users(query={"login": login})[0]
+        user = db.get_users(query={"login": email})[0]
 
-    token = create_token(user['id'], user['name'], login, provider='basic')
+    if email in app.config['ADMIN_USERS']:
+        role = 'admin'
+    else:
+        role = 'user'
+
+    if role == 'admin':
+        customer = None
+    else:
+        customer = db.get_customer_by_reference(email)
+        print customer
+        if not customer:
+            return jsonify(status="error", message="No customer lookup defined for user %s" % email), 403
+
+    token = create_token(user['id'], user['name'], email, provider='basic', customer=customer, role=role)
     return jsonify(token=token)
 
 

--- a/alerta/app/auth.py
+++ b/alerta/app/auth.py
@@ -177,10 +177,11 @@ def login():
     if role == 'admin':
         customer = None
     else:
-        customer = db.get_customer_by_reference(email)
+        domain = email.split('@')[1]
+        customer = db.get_customer_by_reference(domain)
         print customer
         if not customer:
-            return jsonify(status="error", message="No customer lookup defined for user %s" % email), 403
+            return jsonify(status="error", message="No customer lookup defined for domain %s" % domain), 403
 
     token = create_token(user['id'], user['name'], email, provider='basic', customer=customer, role=role)
     return jsonify(token=token)
@@ -216,10 +217,10 @@ def signup():
     if role == 'admin':
         customer = None
     else:
-        customer = db.get_customer_by_reference(email)
-        print customer
+        domain = email.split('@')[1]
+        customer = db.get_customer_by_reference(domain)
         if not customer:
-            return jsonify(status="error", message="No customer lookup defined for user %s" % email), 403
+            return jsonify(status="error", message="No customer lookup defined for domain %s" % domain), 403
 
     token = create_token(user['id'], user['name'], email, provider='basic', customer=customer, role=role)
     return jsonify(token=token)

--- a/alerta/app/auth.py
+++ b/alerta/app/auth.py
@@ -179,7 +179,6 @@ def login():
     else:
         domain = email.split('@')[1]
         customer = db.get_customer_by_reference(domain)
-        print customer
         if not customer:
             return jsonify(status="error", message="No customer lookup defined for domain %s" % domain), 403
 

--- a/alerta/app/database.py
+++ b/alerta/app/database.py
@@ -106,6 +106,10 @@ class Mongo(object):
 
         return self._db
 
+    def get_info(self):
+
+        return self._db.name
+
     def get_version(self):
 
         return self._db.client.server_info()['version']

--- a/alerta/app/database.py
+++ b/alerta/app/database.py
@@ -1105,7 +1105,7 @@ class Mongo(object):
         if login:
             return bool(self._db.users.find_one({"login": login}))
 
-    def save_user(self, id, name, login, password=None, provider="", text="", customer=None):
+    def save_user(self, id, name, login, password=None, provider="", text=""):
 
         if self.is_user_valid(login=login):
             return
@@ -1116,8 +1116,7 @@ class Mongo(object):
             "login": login,
             "createTime": datetime.datetime.utcnow(),
             "provider": provider,
-            "text": text,
-            "customer": customer
+            "text": text
         }
 
         if password:

--- a/alerta/app/views.py
+++ b/alerta/app/views.py
@@ -704,9 +704,8 @@ def create_user():
         password = request.json.get("password", None)
         provider = request.json["provider"]
         text = request.json.get("text", "")
-        customer = request.json.get("customer", None)
         try:
-            user = db.save_user(str(uuid4()), name, login, password, provider, text, customer)
+            user = db.save_user(str(uuid4()), name, login, password, provider, text)
         except Exception as e:
             return jsonify(status="error", message=str(e)), 500
     else:


### PR DESCRIPTION
To use customer views with basic auth logins:
1. set AUTH_REQUIRED = True
2. add your email address ADMIN_USERS list
3. create customer mappings based on email domains in web console
eg. Customer="Example Corp" -> Email domain="example.com"