### PR TITLE
Use alarm['AlarmName'] instead of alarm['Trigger']['MetricName'] for …

### DIFF
--- a/alerta/app/webhooks/views.py
+++ b/alerta/app/webhooks/views.py
@@ -58,7 +58,7 @@ def parse_notification(notification):
 
         return Alert(
             resource='%s:%s' % (alarm['Trigger']['Dimensions'][0]['name'], alarm['Trigger']['Dimensions'][0]['value']),
-            event=alarm['Trigger']['MetricName'],
+            event=alarm['AlarmName'],
             environment='Production',
             severity=cw_state_to_severity(alarm['NewStateValue']),
             service=[alarm['AWSAccountId']],


### PR DESCRIPTION
…event in cloudwatch webhook

Fixes #149 