### PR TITLE
Reopen closed alerts not just if trend indication is more severe

### DIFF
--- a/alerta/app/severity_code.py
+++ b/alerta/app/severity_code.py
@@ -128,7 +128,7 @@ def trend(previous, current):
 def status_from_severity(previous_severity, current_severity, current_status=None):
     if current_severity in [NORMAL, CLEARED, OK]:
         return status_code.CLOSED
-    if current_status == status_code.EXPIRED:
+    if current_status in [status_code.CLOSED, status_code.EXPIRED]:
         return status_code.OPEN
     if trend(previous_severity, current_severity) == MORE_SEVERE:
         return status_code.OPEN

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -278,6 +278,36 @@ class AlertTestCase(unittest.TestCase):
         data = json.loads(response.data.decode('utf-8'))
         self.assertEqual(data['alert']['status'], 'closed')
 
+        # severity == warning -> status=open
+        response = self.app.post('/alert', data=json.dumps(self.warn_alert), headers=self.headers)
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['alert']['status'], 'open')
+
+    def test_duplicate_status(self):
+
+        # create alert
+        response = self.app.post('/alert', data=json.dumps(self.fatal_alert), headers=self.headers)
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['alert']['duplicateCount'], 0)
+
+        alert_id = data['id']
+
+        # close alert
+        response = self.app.post('/alert/' + alert_id + '/status', data=json.dumps({'status': 'closed'}), headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        response = self.app.get('/alert/' + alert_id)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['alert']['status'], "closed")
+
+        # duplicate alert -> status=open
+        response = self.app.post('/alert', data=json.dumps(self.fatal_alert), headers=self.headers)
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['alert']['status'], 'open')
+
     def test_alert_tagging(self):
 
         # create alert


### PR DESCRIPTION

<img width="959" alt="screen shot 2016-02-21 at 16 29 24" src="https://cloud.githubusercontent.com/assets/615057/13203838/578c8442-d8b8-11e5-8b77-aa40a83ec465.png">


Reported by @hasso "noticed that receiving a duplicate for closed alarm doesn't reopen it. is it intentional?"