### PR TITLE
Move cffi to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 gunicorn
+cffi
 -e .

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setuptools.setup(
         'python-dateutil',
         'pytz',
         'PyJWT',
-        'cffi',
         'bcrypt'
     ],
     include_package_data=True,


### PR DESCRIPTION
Heroku [python buildpack](https://elements.heroku.com/buildpacks/heroku/heroku-buildpack-python) won't install libcffi unless cffi is in requirements.txt file. See [cryptography](https://github.com/heroku/heroku-buildpack-python/blob/master/bin/steps/cryptography) build step script.
