### PR TITLE
Cap the number of alert history entries

### DIFF
--- a/alerta/app/database.py
+++ b/alerta/app/database.py
@@ -341,11 +341,14 @@ class Mongo(object):
         if status != previous_status:
             update['$push'] = {
                 "history": {
-                    "event": alert.event,
-                    "status": status,
-                    "text": "duplicate alert status change",
-                    "id": alert.id,
-                    "updateTime": now
+                    '$each': [{
+                        "event": alert.event,
+                        "status": status,
+                        "text": "duplicate alert status change",
+                        "id": alert.id,
+                        "updateTime": now
+                    }],
+                    '$slice': -abs(app.config['HISTORY_LIMIT'])
                 }
             }
 
@@ -436,20 +439,23 @@ class Mongo(object):
                 "lastReceiveId": alert.id,
                 "lastReceiveTime": now
             },
-            '$pushAll': {
-                "history": [{
-                    "event": alert.event,
-                    "severity": alert.severity,
-                    "value": alert.value,
-                    "text": alert.text,
-                    "id": alert.id,
-                    "updateTime": alert.create_time
-                }]
+            '$push': {
+                "history": {
+                    '$each': [{
+                        "event": alert.event,
+                        "severity": alert.severity,
+                        "value": alert.value,
+                        "text": alert.text,
+                        "id": alert.id,
+                        "updateTime": alert.create_time
+                    }],
+                    '$slice': -abs(app.config['HISTORY_LIMIT'])
+                }
             }
         }
 
         if status != previous_status:
-            update['$pushAll']['history'].append({
+            update['$push']['history']['$each'].append({
                 "event": alert.event,
                 "status": status,
                 "text": "correlated alert status change",
@@ -647,11 +653,14 @@ class Mongo(object):
             '$set': {"status": status},
             '$push': {
                 "history": {
-                    "event": event,
-                    "status": status,
-                    "text": text,
-                    "id": id,
-                    "updateTime": now
+                    '$each': [{
+                        "event": event,
+                        "status": status,
+                        "text": text,
+                        "id": id,
+                        "updateTime": now
+                    }],
+                    '$slice': -abs(app.config['HISTORY_LIMIT'])
                 }
             }
         }

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -12,7 +12,7 @@ DEBUG = False
 SECRET_KEY = r'0Afk\(,8$cr(Y8:MA""knd>[@$U[G.eQL6DjAmVs'
 
 QUERY_LIMIT = 10000  # maximum number of alerts returned by a single query
-HISTORY_LIMIT = 100  #
+HISTORY_LIMIT = 100  # cap the number of alert history entries
 
 # MongoDB
 MONGO_HOST = 'localhost'


### PR DESCRIPTION
This doesn't change anything in the UI as Alerta would alreadt cap the number displayed to the `HISTORY_LIMIT` setting. This change enforces that limit at the database level so that the number of history entries doesn't grow without limit and fill the database.
<img width="1004" alt="screen shot 2016-04-01 at 21 37 44" src="https://cloud.githubusercontent.com/assets/615057/14219399/ff0691fa-f851-11e5-9331-2c3438ad0fa8.png">
