### PR TITLE
Use BASE_URL setting to fix http links

### DIFF
--- a/alerta/app/__init__.py
+++ b/alerta/app/__init__.py
@@ -14,6 +14,9 @@ app.config.from_object('alerta.settings')
 app.config.from_pyfile('/etc/alertad.conf', silent=True)
 app.config.from_envvar('ALERTA_SVR_CONF_FILE', silent=True)
 
+if 'BASE_URL' in os.environ:
+    app.config['BASE_URL'] = os.environ['BASE_URL']
+
 if 'SECRET_KEY' in os.environ:
     app.config['SECRET_KEY'] = os.environ['SECRET_KEY']
 

--- a/alerta/app/templates/index.html
+++ b/alerta/app/templates/index.html
@@ -11,12 +11,12 @@
 <h2>Examples</h2>
 <p>Some basic examples of using the API are:
 <ul>
-    <li> <a href="/alerts">Alerts</a>
-    <li> <a href="/environments">Environments</a>
-    <li> <a href="/services">Services</a>
-    <li> <a href="/alerts/count">Alert Counts</a>
-    <li> <a href="/alerts/top10">Alert Top 10</a>
-    <li> <a href="/heartbeats">Heartbeats</a>
+    <li> <a href="{{ base_url }}/alerts">Alerts</a>
+    <li> <a href="{{ base_url }}/environments">Environments</a>
+    <li> <a href="{{ base_url }}/services">Services</a>
+    <li> <a href="{{ base_url }}/alerts/count">Alert Counts</a>
+    <li> <a href="{{ base_url }}/alerts/top10">Alert Top 10</a>
+    <li> <a href="{{ base_url }}/heartbeats">Heartbeats</a>
 </ul>
 
 <h2>Query parameters</h2>

--- a/alerta/app/utils.py
+++ b/alerta/app/utils.py
@@ -6,6 +6,11 @@ import re
 from functools import wraps
 from flask import request, g, current_app
 
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
+
 from alerta.app import app, db
 from alerta.app.metrics import Counter, Timer
 from alerta.plugins import load_plugins, RejectException
@@ -53,14 +58,8 @@ def jsonp(func):
     return decorated
 
 
-def absolute_url(path=None):
-    base_url = app.config.get('BASE_URL', None)
-    if not base_url:
-        return request.base_url.replace(request.path, '') + path
-    elif base_url.startswith('/'):
-        return request.base_url.replace(request.path, base_url) + path
-    else:
-        return base_url + path
+def absolute_url(path=''):
+    return urljoin(request.base_url.rstrip('/'), app.config.get('BASE_URL', '') + path)
 
 
 PARAMS_EXCLUDE = [

--- a/alerta/app/views.py
+++ b/alerta/app/views.py
@@ -48,7 +48,7 @@ def index():
     for rule in app.url_map.iter_rules():
         if rule.endpoint not in ['test', 'static']:
             rules.append(rule)
-    return render_template('index.html', rules=rules)
+    return render_template('index.html', base_url=absolute_url(), rules=rules)
 
 
 @app.route('/alerts', methods=['OPTIONS', 'GET'])


### PR DESCRIPTION
If Alerta API is hosted behind a proxy, for example, then set `BASE_URL` to ensure links in responses are correct.

**Example**
```
BASE_URL = 'http://api.alerta.io'
```
