### PR TITLE
Allow users to create API keys even though auth is not enabled

### DIFF
--- a/alerta/app/auth.py
+++ b/alerta/app/auth.py
@@ -87,9 +87,6 @@ def auth_required(f):
     @wraps(f)
     def decorated(*args, **kwargs):
 
-        if not app.config['AUTH_REQUIRED']:
-            return f(*args, **kwargs)
-
         if 'api-key' in request.args:
             key = request.args['api-key']
             try:
@@ -139,6 +136,9 @@ def auth_required(f):
             g.user = payload['login']
             g.customer = payload.get('customer', None)
             g.role = payload.get('role', None)
+            return f(*args, **kwargs)
+
+        if not app.config['AUTH_REQUIRED']:
             return f(*args, **kwargs)
 
         return authenticate('Authentication required')

--- a/alerta/app/auth.py
+++ b/alerta/app/auth.py
@@ -102,9 +102,7 @@ def auth_required(f):
             g.role = role(ki['user'])
             return f(*args, **kwargs)
 
-        auth_header = request.headers.get('Authorization')
-        if not auth_header:
-            return authenticate('Missing authorization API Key or Bearer Token')
+        auth_header = request.headers.get('Authorization', '')
 
         m = re.match('Key (\S+)', auth_header)
         if m:
@@ -141,7 +139,7 @@ def auth_required(f):
         if not app.config['AUTH_REQUIRED']:
             return f(*args, **kwargs)
 
-        return authenticate('Authentication required')
+        return authenticate('Missing authorization API Key or Bearer Token')
 
     return decorated
 

--- a/alerta/app/views.py
+++ b/alerta/app/views.py
@@ -915,16 +915,19 @@ def get_keys():
 @jsonp
 def create_key():
 
-    if g.get('role', None) != 'admin':
-        user = g.user
-        customer = g.customer
-    else:
-        user = request.json.get('user', g.user)
-        customer = request.json.get('customer', None)
+    try:
+        if g.get('role', None) != 'admin':
+            user = g.user
+            customer = g.get('customer', None)
+        else:
+            user = request.json.get('user', g.user)
+            customer = request.json.get('customer', None)
+    except AttributeError:
+        return jsonify(status="error", message="Must supply 'user' as parameter"), 400
 
     type = request.json.get("type", "read-only")
     if type not in ['read-only', 'read-write']:
-        return jsonify(status="error", message="API key must be read-only or read-write"), 400
+        return jsonify(status="error", message="API key 'type' must be 'read-only' or 'read-write'"), 400
 
     text = request.json.get("text", "API Key for %s" % user)
     try:


### PR DESCRIPTION
As long as a 'user' is supplied allows API keys to be created.
This was the behaviour that was supported in previous versions.

Fixed #190