### PR TITLE
Update attributes and tags for duplicate alerts

### DIFF
--- a/alerta/app/database.py
+++ b/alerta/app/database.py
@@ -331,6 +331,8 @@ class Mongo(object):
                 "status": status,
                 "value": alert.value,
                 "text": alert.text,
+                "tags": alert.tags,
+                "attributes": alert.attributes,
                 "rawData": alert.raw_data,
                 "repeat": True,
                 "lastReceiveId": alert.id,


### PR DESCRIPTION
This is so that attributes and tags can be updated using `db.save_duplicate(alert)` in `post_receive()` hooks like this ...

```
from alerta.plugins import PluginBase
from alerta.app import db

class Test(PluginBase):

    def pre_receive(self, alert):
        pass

    def post_receive(self, alert):
        alert.attributes['foo'] = 'bar'
        db.save_duplicate(alert)
        return

    def status_change(self, alert, status, text):
        return
```