### PR TITLE
Only assign api-key if param has a value

### DIFF
--- a/alerta/app/auth.py
+++ b/alerta/app/auth.py
@@ -87,8 +87,8 @@ def auth_required(f):
     @wraps(f)
     def decorated(*args, **kwargs):
 
-        if 'api-key' in request.args:
-            key = request.args['api-key']
+        key = request.args.get('api-key', None)
+        if key:
             try:
                 ki = verify_api_key(key, request.method)
             except AuthError as e:


### PR DESCRIPTION
```
$ curl http://localhost:8080/alerts?api-key=
{
  "status": "error",
  "message": "API key '' is invalid”
}
```