### PR TITLE
Only update specific attributes when injesting alerts and add endpoint to update attributes

### DIFF
--- a/alerta/app/database.py
+++ b/alerta/app/database.py
@@ -332,7 +332,6 @@ class Mongo(object):
                 "value": alert.value,
                 "text": alert.text,
                 "tags": alert.tags,
-                "attributes": alert.attributes,
                 "rawData": alert.raw_data,
                 "repeat": True,
                 "lastReceiveId": alert.id,
@@ -340,6 +339,10 @@ class Mongo(object):
             },
             '$inc': {"duplicateCount": 1}
         }
+
+        attributes = {'attributes.'+k: v for k, v in alert.attributes.items() if not k.startswith('_')}
+        update['$set'].update(attributes)
+
         if status != previous_status:
             update['$push'] = {
                 "history": {
@@ -431,7 +434,6 @@ class Mongo(object):
                 "value": alert.value,
                 "text": alert.text,
                 "tags": alert.tags,
-                "attributes": alert.attributes,
                 "createTime": alert.create_time,
                 "rawData": alert.raw_data,
                 "duplicateCount": 0,
@@ -457,6 +459,9 @@ class Mongo(object):
                 }
             }
         }
+
+        attributes = {'attributes.'+k: v for k, v in alert.attributes.items() if not k.startswith('_')}
+        update['$set'].update(attributes)
 
         if status != previous_status:
             update['$push']['history']['$each'].append({
@@ -534,7 +539,7 @@ class Mongo(object):
                 "updateTime": now
             })
 
-        alert = {
+        new = {
             "_id": alert.id,
             "resource": alert.resource,
             "event": alert.event,
@@ -547,7 +552,7 @@ class Mongo(object):
             "value": alert.value,
             "text": alert.text,
             "tags": alert.tags,
-            "attributes": alert.attributes,
+            "attributes": {k: v for k, v in alert.attributes.items() if not k.startswith('_')},
             "origin": alert.origin,
             "type": alert.event_type,
             "createTime": alert.create_time,
@@ -564,40 +569,39 @@ class Mongo(object):
             "history": history
         }
 
-        LOG.debug('Insert new alert in database: %s', alert)
+        LOG.debug('Insert new alert in database: %s', new)
 
-        response = self._db.alerts.insert_one(alert)
-
+        response = self._db.alerts.insert_one(new)
         if not response:
             return
 
         return AlertDocument(
-            id=alert['_id'],
-            resource=alert['resource'],
-            event=alert['event'],
-            environment=alert['environment'],
-            severity=alert['severity'],
-            correlate=alert['correlate'],
-            status=alert['status'],
-            service=alert['service'],
-            group=alert['group'],
-            value=alert['value'],
-            text=alert['text'],
-            tags=alert['tags'],
-            attributes=alert['attributes'],
-            origin=alert['origin'],
-            event_type=alert['type'],
-            create_time=alert['createTime'],
-            timeout=alert['timeout'],
-            raw_data=alert['rawData'],
-            customer=alert['customer'],
-            duplicate_count=alert['duplicateCount'],
-            repeat=alert['repeat'],
-            previous_severity=alert['previousSeverity'],
-            trend_indication=alert['trendIndication'],
-            receive_time=alert['receiveTime'],
-            last_receive_id=alert['lastReceiveId'],
-            last_receive_time=alert['lastReceiveTime'],
+            id=new['_id'],
+            resource=new['resource'],
+            event=new['event'],
+            environment=new['environment'],
+            severity=new['severity'],
+            correlate=new['correlate'],
+            status=new['status'],
+            service=new['service'],
+            group=new['group'],
+            value=new['value'],
+            text=new['text'],
+            tags=new['tags'],
+            attributes=new['attributes'],
+            origin=new['origin'],
+            event_type=new['type'],
+            create_time=new['createTime'],
+            timeout=new['timeout'],
+            raw_data=new['rawData'],
+            customer=new['customer'],
+            duplicate_count=new['duplicateCount'],
+            repeat=new['repeat'],
+            previous_severity=new['previousSeverity'],
+            trend_indication=new['trendIndication'],
+            receive_time=new['receiveTime'],
+            last_receive_id=new['lastReceiveId'],
+            last_receive_time=new['lastReceiveTime'],
             history=list()
         )
 

--- a/alerta/app/database.py
+++ b/alerta/app/database.py
@@ -340,8 +340,8 @@ class Mongo(object):
             '$inc': {"duplicateCount": 1}
         }
 
-        # exclude private attributes (starting with an underscore) from update
-        attributes = {'attributes.'+k: v for k, v in alert.attributes.items() if not k.startswith('_')}
+        # only update those attributes that are specifically defined
+        attributes = {'attributes.'+k: v for k, v in alert.attributes.items()}
         update['$set'].update(attributes)
 
         if status != previous_status:
@@ -461,8 +461,8 @@ class Mongo(object):
             }
         }
 
-        # exclude private attributes (starting with an underscore) from update
-        attributes = {'attributes.'+k: v for k, v in alert.attributes.items() if not k.startswith('_')}
+        # only update those attributes that are specifically defined
+        attributes = {'attributes.'+k: v for k, v in alert.attributes.items()}
         update['$set'].update(attributes)
 
         if status != previous_status:
@@ -558,7 +558,7 @@ class Mongo(object):
             "value": alert.value,
             "text": alert.text,
             "tags": alert.tags,
-            "attributes": {k: v for k, v in alert.attributes.items() if not k.startswith('_')},
+            "attributes": alert.attributes,
             "origin": alert.origin,
             "type": alert.event_type,
             "createTime": alert.create_time,

--- a/alerta/app/database.py
+++ b/alerta/app/database.py
@@ -730,6 +730,16 @@ class Mongo(object):
 
         return response.matched_count > 0
 
+    def set_attributes(self, id, attrs):
+        """
+        Set attributes.
+        """
+        response = self._db.alerts.update_one(
+            {'_id': {'$regex': '^' + id}},
+            {'$set': {'attributes.' + k: v for k, v in attrs.items()}}
+        )
+        return response.matched_count > 0
+
     def delete_alert(self, id):
 
         response = self._db.alerts.delete_one({'_id': {'$regex': '^' + id}})

--- a/alerta/app/views.py
+++ b/alerta/app/views.py
@@ -341,7 +341,7 @@ def untag_alert(id):
 @cross_origin()
 @auth_required
 @jsonp
-def set_attributes(id):
+def update_attributes(id):
 
     attrs_started = attrs_timer.start_timer()
     customer = g.get('customer', None)
@@ -362,7 +362,7 @@ def set_attributes(id):
         return jsonify(status="error", message="must supply 'attributes' as parameter"), 400
 
     try:
-        alert = db.set_attributes(id, attributes)
+        alert = db.update_attributes(id, attributes)
     except Exception as e:
         attrs_timer.stop_timer(attrs_started)
         return jsonify(status="error", message=str(e)), 500

--- a/alerta/app/views.py
+++ b/alerta/app/views.py
@@ -23,6 +23,7 @@ receive_timer = Timer('alerts', 'received', 'Received alerts', 'Total time to pr
 delete_timer = Timer('alerts', 'deleted', 'Deleted alerts', 'Total time to process number of deleted alerts')
 status_timer = Timer('alerts', 'status', 'Alert status change', 'Total time and number of alerts with status changed')
 tag_timer = Timer('alerts', 'tagged', 'Tagging alerts', 'Total time to tag number of alerts')
+attrs_timer = Timer('alerts', 'attributes', 'Alert attributes change', 'Total time and number of alerts with attributes changed')
 untag_timer = Timer('alerts', 'untagged', 'Removing tags from alerts', 'Total time to un-tag number of alerts')
 
 
@@ -333,6 +334,44 @@ def untag_alert(id):
     if response:
         return jsonify(status="ok")
     else:
+        return jsonify(status="error", message="not found"), 404
+
+
+@app.route('/alert/<id>/attributes', methods=['OPTIONS', 'PUT'])
+@cross_origin()
+@auth_required
+@jsonp
+def set_attributes(id):
+
+    attrs_started = attrs_timer.start_timer()
+    customer = g.get('customer', None)
+    try:
+        alert = db.get_alert(id=id, customer=customer)
+    except Exception as e:
+        attrs_timer.stop_timer(attrs_started)
+        return jsonify(status="error", message=str(e)), 500
+
+    if not alert:
+        attrs_timer.stop_timer(attrs_started)
+        return jsonify(status="error", message="not found", total=0, alert=None), 404
+
+    attributes = request.json.get('attributes', None)
+
+    if not attributes:
+        attrs_timer.stop_timer(attrs_started)
+        return jsonify(status="error", message="must supply 'attributes' as parameter"), 400
+
+    try:
+        alert = db.set_attributes(id, attributes)
+    except Exception as e:
+        attrs_timer.stop_timer(attrs_started)
+        return jsonify(status="error", message=str(e)), 500
+
+    if alert:
+        attrs_timer.stop_timer(attrs_started)
+        return jsonify(status="ok")
+    else:
+        attrs_timer.stop_timer(attrs_started)
         return jsonify(status="error", message="not found"), 404
 
 


### PR DESCRIPTION
Only attributes sent to the alerta server will be updated when processing duplicate or correlated alerts. This is so that individual attributes can be managed by the user or another system using either the update attributes endpoint (ie. `PUT /alert/<id>/attributes`) or the database call to `update_attributes()`.

```
from alerta.plugins import PluginBase
from alerta.app import db

class Test(PluginBase):

    def pre_receive(self, alert):
        pass

    def post_receive(self, alert):
        db.update_attributes(alert.id, {'foo': 'bar', 'baz': None})
        return

    def status_change(self, alert, status, text):
        return
```

Todo
- [ ] update documentation
- [x] update examples
- [x] write tests