### PR TITLE
Importing flask.ext.cors is deprecated, use flask_cors instead

### DIFF
--- a/alerta/app/__init__.py
+++ b/alerta/app/__init__.py
@@ -4,7 +4,7 @@ import sys
 import logging
 
 from flask import Flask
-from flask.ext.cors import CORS
+from flask_cors import CORS
 
 LOG_FORMAT = '%(asctime)s - %(name)s[%(process)d]: %(levelname)s - %(message)s'
 

--- a/alerta/app/management/views.py
+++ b/alerta/app/management/views.py
@@ -4,7 +4,7 @@ import datetime
 import logging
 
 from flask import request, Response, url_for, jsonify, render_template
-from flask.ext.cors import cross_origin
+from flask_cors import cross_origin
 
 from alerta.app import app, db
 from alerta.app.auth import auth_required

--- a/alerta/app/oembed/views.py
+++ b/alerta/app/oembed/views.py
@@ -1,9 +1,7 @@
-import json
-import datetime
 import requests
 
 from flask import request, render_template
-from flask.ext.cors import cross_origin
+from flask_cors import cross_origin
 
 try:
     from urllib.parse import urlparse
@@ -11,13 +9,13 @@ except ImportError:
     from urlparse import urlparse
 
 from alerta.app import app
-from alerta.alert import Alert
 from alerta.app.utils import jsonify, jsonp
 from alerta.app.metrics import Timer
 
 LOG = app.logger
 
 oembed_timer = Timer('oEmbed', 'request', 'oEmbed request', 'Total time to process number of oEmbed requests')
+
 
 @app.route('/oembed', defaults={'format': 'json'})
 @app.route('/oembed.<format>', methods=['OPTIONS', 'GET'])

--- a/alerta/app/views.py
+++ b/alerta/app/views.py
@@ -1,7 +1,7 @@
 import datetime
 
 from flask import g, request, render_template
-from flask.ext.cors import cross_origin
+from flask_cors import cross_origin
 from uuid import uuid4
 
 from alerta.app import app, db

--- a/alerta/app/webhooks/views.py
+++ b/alerta/app/webhooks/views.py
@@ -4,7 +4,7 @@ import datetime
 from copy import copy
 from dateutil.parser import parse as parse_date
 from flask import g, request
-from flask.ext.cors import cross_origin
+from flask_cors import cross_origin
 
 from alerta.app import app, db
 from alerta.app.auth import auth_required


### PR DESCRIPTION
```
Successfully installed alerta-server-4.7.23 alerta-slack-0.1.4 gunicorn-19.6.0

travis_time:end:29db4b59:start=1465557849076386587,finish=1465557850424999225,duration=1348612638
[0Ktravis_fold:end:install.2
[0Ktravis_time:start:1236878a
[0K$ nosetests tests/test_alerts.py tests/test_auth.py tests/test_heartbeats.py tests/test_metrics.py
/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/flask/exthook.py:71: ExtDeprecationWarning: Importing flask.ext.cors is deprecated, use flask_cors instead.
  .format(x=modname), ExtDeprecationWarning
2016-06-10 11:24:10,829 - alerta.app[2646]: INFO - Server plug-in 'reject' enabled.
2016-06-10 11:24:10,834 - alerta.app[2646]: INFO - Server plug-in 'reject' enabled.
..................
----------------------------------------------------------------------
Ran 18 tests in 1.913s

OK

travis_time:end:1236878a:start=1465557850428873115,finish=1465557853326326113,duration=2897452998
[0K
[32;1mThe command "nosetests tests/test_alerts.py tests/test_auth.py tests/test_heartbeats.py tests/test_metrics.py" exited with 0.[0m

Done. Your build exited with 0.
```