### PR TITLE
Only evaluate plugin for alert if routing rule matches

### DIFF
--- a/alerta/app/views.py
+++ b/alerta/app/views.py
@@ -11,11 +11,11 @@ from alerta.app.utils import absolute_url, jsonp, parse_fields, process_alert, p
 from alerta.app.metrics import Timer
 from alerta.app.alert import Alert
 from alerta.app.heartbeat import Heartbeat
-from alerta.plugins import load_plugins, RejectException
+from alerta.plugins import Plugins, RejectException
 
 LOG = app.logger
 
-plugins = load_plugins()
+plugins = Plugins()
 
 # Set-up metrics
 gets_timer = Timer('alerts', 'queries', 'Alert queries', 'Total time to process number of alert queries')

--- a/alerta/plugins/__init__.py
+++ b/alerta/plugins/__init__.py
@@ -66,7 +66,7 @@ class Plugins(object):
 
     def routing(self, alert):
 
-        if self.rules:
+        if self.rules and self.plugins:
             return self.rules(alert, self.plugins)
         else:
             return self.plugins.values()

--- a/contrib/routing/README.md
+++ b/contrib/routing/README.md
@@ -1,0 +1,18 @@
+Example plug-in routing rules
+=============================
+
+If severity is "debug" do not apply the "reject" policy to enforce a valid environment and a service.
+
+```python
+def rules(alert, plugins):
+
+    if alert.severity == 'debug':
+        return []
+    else:
+        return [plugins['reject']]
+```
+
+Installation
+------------
+
+    $ python setup.py install

--- a/contrib/routing/routing.py
+++ b/contrib/routing/routing.py
@@ -1,0 +1,10 @@
+
+
+def rules(alert, plugins):
+
+    print alert
+
+    if 'reject' in alert.text:
+        return [plugins['reject']]
+    else:
+        return [plugins['normalise'], plugins['enhance']]

--- a/contrib/routing/routing.py
+++ b/contrib/routing/routing.py
@@ -1,10 +1,8 @@
-
+# Example plugin routing rules file
 
 def rules(alert, plugins):
 
-    print alert
-
-    if 'reject' in alert.text:
-        return [plugins['reject']]
+    if alert.severity == 'debug':
+        return []
     else:
-        return [plugins['normalise'], plugins['enhance']]
+        return [plugins['reject']]

--- a/contrib/routing/setup.py
+++ b/contrib/routing/setup.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+import setuptools
+
+version = '0.0.1'
+
+setuptools.setup(
+    name="alerta-routing",
+    version=version,
+    description='Alerta routing rules for plugins',
+    url='https://github.com/alerta/alerta-contrib',
+    license='Apache License 2.0',
+    author='Nick Satterly',
+    author_email='nick.satterly@theguardian.com',
+    py_modules=['routing'],
+    install_requires=[
+        'requests',
+        'alerta-server'
+    ],
+    include_package_data=True,
+    zip_safe=False,
+    entry_points={
+        'alerta.routing': [
+          'rules = routing:rules'
+        ]
+    }
+)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -12,7 +12,7 @@ class PluginsTestCase(unittest.TestCase):
 
         app.config['TESTING'] = True
         app.config['AUTH_REQUIRED'] = False
-        app.config['PLUGINS'] = ['amqp', 'enhance', 'logstash', 'normalise', 'reject', 'sns']
+        app.config['PLUGINS'] = ['reject']
         self.app = app.test_client()
 
         self.resource = str(uuid4()).upper()[:8]
@@ -22,6 +22,15 @@ class PluginsTestCase(unittest.TestCase):
             'resource': self.resource,
             'environment': 'Production',
             'service': [],  # alert will be rejected because service not defined
+            'severity': 'warning',
+            'correlate': ['node_down', 'node_marginal', 'node_up']
+        }
+
+        self.accept_alert = {
+            'event': 'node_marginal',
+            'resource': self.resource,
+            'environment': 'Production',
+            'service': ['Network'],  # alert will be accepted because service not defined
             'severity': 'warning',
             'correlate': ['node_down', 'node_marginal', 'node_up']
         }
@@ -36,6 +45,16 @@ class PluginsTestCase(unittest.TestCase):
 
     def test_reject_alert(self):
 
-        # create alert
+        # create alert that will be rejected
         response = self.app.post('/alert', data=json.dumps(self.reject_alert), headers=self.headers)
         self.assertEqual(response.status_code, 403)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['status'], 'error')
+        self.assertEqual(data['message'], '[POLICY] Alert must define a service')
+
+        # create alert that will be accepted
+        response = self.app.post('/alert', data=json.dumps(self.accept_alert), headers=self.headers)
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['status'], 'ok')
+        self.assertRegexpMatches(data['id'], '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}')


### PR DESCRIPTION
Route alerts to plugins based on user-defined rules that reference alert attribute values. 

- [x] add tests for current plugins
- [ ] add test for routing rules

Fixes #241 