### PR TITLE
Set default switch status from config settings

### DIFF
--- a/alerta/app/management/views.py
+++ b/alerta/app/management/views.py
@@ -17,8 +17,8 @@ LOG = logging.getLogger(__name__)
 
 
 switches = [
-    Switch('auto-refresh-allow', 'Allow consoles to auto-refresh alerts', SwitchState.ON),
-    Switch('sender-api-allow', 'Allow alerts to be submitted via the API', SwitchState.ON)
+    Switch('auto-refresh-allow', 'Allow consoles to auto-refresh alerts', SwitchState.to_state(app.config['AUTO_REFRESH_ALLOW'])),
+    Switch('sender-api-allow', 'Allow alerts to be submitted via the API', SwitchState.to_state(app.config['SENDER_API_ALLOW']))
 ]
 total_alert_gauge = Gauge('alerts', 'total', 'Total alerts', 'Total number of alerts in the database')
 started = time.time() * 1000

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -37,6 +37,10 @@ ALLOWED_GITLAB_GROUPS = ['*']
 TOKEN_EXPIRE_DAYS = 14
 API_KEY_EXPIRE_DAYS = 365  # 1 year
 
+# switches
+AUTO_REFRESH_ALLOW = 'ON'  # set to 'OFF' to reduce load on API server by forcing clients to manually refresh
+SENDER_API_ALLOW = 'ON'    # set to 'OFF' to block clients from sending new alerts to API server
+
 CORS_ALLOW_HEADERS = ['Content-Type', 'Authorization', 'Access-Control-Allow-Origin']
 CORS_ORIGINS = [
     'http://try.alerta.io',


### PR DESCRIPTION
Can now set default values switch settings in the server config ...

```python
AUTO_REFRESH_ALLOW = 'OFF'
SENDER_API_ALLOW = 'ON'
```