### PR TITLE
Check MONGODB_URI environment variable

### DIFF
--- a/alerta/app/database.py
+++ b/alerta/app/database.py
@@ -32,6 +32,7 @@ class Mongo(object):
     def connect(self):
 
         mongo_uri = (os.environ.get('MONGO_URI', None) or
+                     os.environ.get('MONGODB_URI', None) or
                      os.environ.get('MONGOHQ_URL', None) or
                      os.environ.get('MONGOLAB_URI', None))
         if mongo_uri:


### PR DESCRIPTION
 mLab MongoDB heroku service is exposed through MONGODB_URI env variable.

 https://devcenter.heroku.com/articles/mongolab#adding-mlab-as-a-heroku-add-on

 This fixes issue: https://github.com/guardian/alerta/issues/261