### PR TITLE
Treat unknown severity as normal for alert processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ build
 .DS_Store
 dist
 rpmbuild
-*.log
+*.log*

--- a/alerta/app/severity_code.py
+++ b/alerta/app/severity_code.py
@@ -20,6 +20,7 @@ from alerta.app import status_code
 # NOTE: The display text in single quotes can be changed depending on preference.
 # eg. CRITICAL = 'critical' or CRITICAL = 'CRITICAL'
 
+AUTH = 'security'
 CRITICAL = 'critical'
 MAJOR = 'major'
 MINOR = 'minor'
@@ -30,7 +31,7 @@ NORMAL = 'normal'
 OK = 'ok'
 INFORM = 'informational'
 DEBUG = 'debug'
-AUTH = 'security'
+TRACE = 'trace'
 UNKNOWN = 'unknown'
 NOT_VALID = 'notValid'
 
@@ -41,6 +42,7 @@ NO_CHANGE = 'noChange'
 SEVERITY_MAP = app.config['SEVERITY_MAP']
 
 _ABBREV_SEVERITY_MAP = {
+    AUTH: 'Sec ',
     CRITICAL: 'Crit',
     MAJOR: 'Majr',
     MINOR: 'Minr',
@@ -51,11 +53,12 @@ _ABBREV_SEVERITY_MAP = {
     OK: 'Ok',
     INFORM: 'Info',
     DEBUG: 'Dbug',
-    AUTH: 'Sec ',
+    TRACE: 'Trce',
     UNKNOWN: 'Unkn',
 }
 
 _COLOR_MAP = {
+    AUTH: '\033[94m',
     CRITICAL: '\033[91m',
     MAJOR: '\033[95m',
     MINOR: '\033[93m',
@@ -66,7 +69,7 @@ _COLOR_MAP = {
     OK: '\033[92m',
     INFORM: '\033[92m',
     DEBUG: '\033[90m',
-    AUTH: '\033[90m',
+    TRACE: '\033[97m',
     UNKNOWN: '\033[90m',
 }
 
@@ -90,6 +93,8 @@ def parse_severity(name):
 
 
 def trend(previous, current):
+    if previous == UNKNOWN:
+        previous = NORMAL  # assume normal for the purposes of calculating trend indication
     if name_to_code(previous) > name_to_code(current):
         return MORE_SEVERE
     elif name_to_code(previous) < name_to_code(current):
@@ -99,6 +104,8 @@ def trend(previous, current):
 
 
 def status_from_severity(previous_severity, current_severity, current_status=status_code.UNKNOWN):
+    if current_severity in [DEBUG, TRACE]:
+        return current_status
     if current_severity in [NORMAL, CLEARED, OK]:
         return status_code.CLOSED
     if current_status in [status_code.CLOSED, status_code.EXPIRED]:

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -53,6 +53,7 @@ CORS_ORIGINS = [
 CORS_SUPPORTS_CREDENTIALS = AUTH_REQUIRED
 
 SEVERITY_MAP = {
+    'security': 0,
     'critical': 1,
     'major': 2,
     'minor': 3,
@@ -63,7 +64,7 @@ SEVERITY_MAP = {
     'ok': 5,
     'informational': 6,
     'debug': 7,
-    'security': 8,
+    'trace': 8,
     'unknown': 9  # default
 }
 

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -109,7 +109,6 @@ class AlertTestCase(unittest.TestCase):
         self.assertEqual(data['alert']['previousSeverity'], self.major_alert['severity'])
         self.assertEqual(data['alert']['trendIndication'], 'moreSevere')
 
-
         # de-duplicate
         response = self.app.post('/alert', data=json.dumps(self.critical_alert), headers=self.headers)
         self.assertEqual(response.status_code, 201)

--- a/tests/test_severity.py
+++ b/tests/test_severity.py
@@ -1,0 +1,240 @@
+
+import unittest
+
+try:
+    import simplejson as json
+except ImportError:
+    import json
+
+from uuid import uuid4
+from alerta.app import app
+
+
+class SeverityTestCase(unittest.TestCase):
+
+    def setUp(self):
+
+        app.config['TESTING'] = True
+        app.config['AUTH_REQUIRED'] = False
+        self.app = app.test_client()
+
+        self.auth_alert = {
+            'event': 'node_pwned',
+            'resource': 'node1',
+            'environment': 'Production',
+            'service': ['Network'],
+            'severity': 'security',
+            'correlate': ['node_trace', 'node_down', 'node_marginal', 'node_up', 'node_pwned'],
+            'tags': ['foo'],
+            'attributes': {'foo': 'abc def', 'bar': 1234, 'baz': False}
+        }
+        self.critical_alert = {
+            'event': 'node_down',
+            'resource': 'node1',
+            'environment': 'Production',
+            'service': ['Network'],
+            'severity': 'critical',
+            'correlate': ['node_trace', 'node_down', 'node_marginal', 'node_up', 'node_pwned']
+        }
+        self.major_alert = {
+            'event': 'node_marginal',
+            'resource': 'node1',
+            'environment': 'Production',
+            'service': ['Network'],
+            'severity': 'major',
+            'correlate': ['node_trace', 'node_down', 'node_marginal', 'node_up', 'node_pwned']
+        }
+        self.warn_alert = {
+            'event': 'node_marginal',
+            'resource': 'node1',
+            'environment': 'Production',
+            'service': ['Network'],
+            'severity': 'warning',
+            'correlate': ['node_trace', 'node_down', 'node_marginal', 'node_up', 'node_pwned']
+        }
+        self.normal_alert = {
+            'event': 'node_up',
+            'resource': 'node1',
+            'environment': 'Production',
+            'service': ['Network'],
+            'severity': 'normal',
+            'correlate': ['node_trace', 'node_down', 'node_marginal', 'node_up', 'node_pwned']
+        }
+
+        self.trace_alert = {
+            'event': 'node_trace',
+            'resource': 'node1',
+            'environment': 'Production',
+            'service': ['Network'],
+            'severity': 'trace',
+            'correlate': ['node_trace', 'node_down', 'node_marginal', 'node_up', 'node_pwned']
+        }
+
+        self.ok_alert = {
+            'event': 'node_ok',
+            'resource': 'node2',
+            'environment': 'Production',
+            'service': ['Network'],
+            'severity': 'ok',
+            'correlate': []
+        }
+
+        self.inform_alert = {
+            'event': 'node_inform',
+            'resource': 'node3',
+            'environment': 'Production',
+            'service': ['Network'],
+            'severity': 'informational',
+            'correlate': []
+        }
+
+        self.headers = {
+            'Content-type': 'application/json'
+        }
+
+    def tearDown(self):
+
+        pass
+
+    def test_inactive(self):
+
+        # prevSev=unknown, sev=ok, status=closed, trend=noChange
+        response = self.app.post('/alert', data=json.dumps(self.ok_alert), headers=self.headers)
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['alert']['duplicateCount'], 0)
+        self.assertEqual(data['alert']['repeat'], False)
+        self.assertEqual(data['alert']['previousSeverity'], 'unknown')
+        self.assertEqual(data['alert']['severity'], 'ok')
+        self.assertEqual(data['alert']['status'], 'closed')
+        self.assertEqual(data['alert']['trendIndication'], 'noChange')
+
+        # prevSev=unknown, sev=informational, status=unknown, trend=lessSevere
+        response = self.app.post('/alert', data=json.dumps(self.inform_alert), headers=self.headers)
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['alert']['duplicateCount'], 0)
+        self.assertEqual(data['alert']['repeat'], False)
+        self.assertEqual(data['alert']['previousSeverity'], 'unknown')
+        self.assertEqual(data['alert']['severity'], 'informational')
+        self.assertEqual(data['alert']['status'], 'unknown')
+        self.assertEqual(data['alert']['trendIndication'], 'lessSevere')
+
+    def test_active(self):
+
+        # prevSev=unknown, sev=major, status=open, trend=moreSevere
+        response = self.app.post('/alert', data=json.dumps(self.major_alert), headers=self.headers)
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['alert']['duplicateCount'], 0)
+        self.assertEqual(data['alert']['repeat'], False)
+        self.assertEqual(data['alert']['previousSeverity'], 'unknown')
+        self.assertEqual(data['alert']['severity'], 'major')
+        self.assertEqual(data['alert']['status'], 'open')
+        self.assertEqual(data['alert']['trendIndication'], 'moreSevere')
+
+        alert_id = data['id']
+
+        # ack alert
+        response = self.app.post('/alert/' + alert_id + '/status', data=json.dumps({'status': 'ack'}), headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        response = self.app.get('/alert/' + alert_id)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['alert']['status'], 'ack')
+
+        # prevSev=unknown, sev=major, status=(current=ack), trend=moreSevere
+        response = self.app.post('/alert', data=json.dumps(self.major_alert), headers=self.headers)
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['alert']['duplicateCount'], 1)
+        self.assertEqual(data['alert']['repeat'], True)
+        self.assertEqual(data['alert']['previousSeverity'], 'unknown')
+        self.assertEqual(data['alert']['severity'], 'major')
+        self.assertEqual(data['alert']['status'], 'ack')
+        self.assertEqual(data['alert']['trendIndication'], 'moreSevere')
+
+        # prevSev=major, sev=critical, status=open, trend=moreSevere
+        response = self.app.post('/alert', data=json.dumps(self.critical_alert), headers=self.headers)
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['alert']['duplicateCount'], 0)
+        self.assertEqual(data['alert']['repeat'], False)
+        self.assertEqual(data['alert']['previousSeverity'], 'major')
+        self.assertEqual(data['alert']['severity'], 'critical')
+        self.assertEqual(data['alert']['status'], 'open')
+        self.assertEqual(data['alert']['trendIndication'], 'moreSevere')
+
+        # prevSev=major, sev=critical, status=(current=open), trend=noChange
+        response = self.app.post('/alert', data=json.dumps(self.critical_alert), headers=self.headers)
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['alert']['duplicateCount'], 1)
+        self.assertEqual(data['alert']['repeat'], True)
+        self.assertEqual(data['alert']['previousSeverity'], 'major')
+        self.assertEqual(data['alert']['severity'], 'critical')
+        self.assertEqual(data['alert']['status'], 'open')
+        self.assertEqual(data['alert']['trendIndication'], 'moreSevere')
+
+        # ack alert
+        response = self.app.post('/alert/' + alert_id + '/status', data=json.dumps({'status': 'ack'}), headers=self.headers)
+        self.assertEqual(response.status_code, 200)
+        response = self.app.get('/alert/' + alert_id)
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['alert']['status'], 'ack')
+
+        # prevSev=critical, sev=warning, status=(current=ack), trend=lessSevere
+        response = self.app.post('/alert', data=json.dumps(self.warn_alert), headers=self.headers)
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['alert']['duplicateCount'], 0)
+        self.assertEqual(data['alert']['repeat'], False)
+        self.assertEqual(data['alert']['previousSeverity'], 'critical')
+        self.assertEqual(data['alert']['severity'], 'warning')
+        self.assertEqual(data['alert']['status'], 'ack')
+        self.assertEqual(data['alert']['trendIndication'], 'lessSevere')
+
+        # prevSev=warning, sev=normal, status=closed, trend=lessSevere
+        response = self.app.post('/alert', data=json.dumps(self.normal_alert), headers=self.headers)
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['alert']['duplicateCount'], 0)
+        self.assertEqual(data['alert']['repeat'], False)
+        self.assertEqual(data['alert']['previousSeverity'], 'warning')
+        self.assertEqual(data['alert']['severity'], 'normal')
+        self.assertEqual(data['alert']['status'], 'closed')
+        self.assertEqual(data['alert']['trendIndication'], 'lessSevere')
+
+        # prevSev=warning, sev=normal, status=closed, trend=noChange
+        response = self.app.post('/alert', data=json.dumps(self.normal_alert), headers=self.headers)
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['alert']['duplicateCount'], 1)
+        self.assertEqual(data['alert']['repeat'], True)
+        self.assertEqual(data['alert']['previousSeverity'], 'warning')
+        self.assertEqual(data['alert']['severity'], 'normal')
+        self.assertEqual(data['alert']['status'], 'closed')
+        self.assertEqual(data['alert']['trendIndication'], 'lessSevere')
+
+        # prevSev=normal, sev=trace, status=closed, trend=lessSevere
+        response = self.app.post('/alert', data=json.dumps(self.trace_alert), headers=self.headers)
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['alert']['duplicateCount'], 0)
+        self.assertEqual(data['alert']['repeat'], False)
+        self.assertEqual(data['alert']['previousSeverity'], 'normal')
+        self.assertEqual(data['alert']['severity'], 'trace')
+        self.assertEqual(data['alert']['status'], 'closed')
+        self.assertEqual(data['alert']['trendIndication'], 'lessSevere')
+
+        # prevSev=trace, sev=security, status=open, trend=moreSevere
+        response = self.app.post('/alert', data=json.dumps(self.auth_alert), headers=self.headers)
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['alert']['duplicateCount'], 0)
+        self.assertEqual(data['alert']['repeat'], False)
+        self.assertEqual(data['alert']['previousSeverity'], 'trace')
+        self.assertEqual(data['alert']['severity'], 'security')
+        self.assertEqual(data['alert']['status'], 'open')
+        self.assertEqual(data['alert']['trendIndication'], 'moreSevere')


### PR DESCRIPTION
This is for cases where a normal alert is received for a resource and no notifications are wanted so the difference between this alert and a normal following a high severity alert is that the `trendIndication` will be `noChange` compare with `lessSevere`.