### PR TITLE
Make default severity less magical

### DIFF
--- a/alerta/app/database.py
+++ b/alerta/app/database.py
@@ -307,7 +307,7 @@ class Mongo(object):
         if alert.status != status_code.UNKNOWN and alert.status != previous_status:
             status = alert.status
         else:
-            status = severity_code.status_from_severity(alert.severity, alert.severity, previous_status)
+            status = status_code.status_from_severity(alert.severity, alert.severity, previous_status)
 
         query = {
             "environment": alert.environment,
@@ -399,7 +399,7 @@ class Mongo(object):
         previous_status = self.get_status(alert)
         trend_indication = severity_code.trend(previous_severity, alert.severity)
         if alert.status == status_code.UNKNOWN:
-            status = severity_code.status_from_severity(previous_severity, alert.severity, previous_status)
+            status = status_code.status_from_severity(previous_severity, alert.severity, previous_status)
         else:
             status = alert.status
 
@@ -511,9 +511,9 @@ class Mongo(object):
         receive id and time, appending all to history. Append to history again if status changes.
         """
 
-        trend_indication = severity_code.trend(severity_code.UNKNOWN, alert.severity)
+        trend_indication = severity_code.trend(app.config['DEFAULT_SEVERITY'], alert.severity)
         if alert.status == status_code.UNKNOWN:
-            status = severity_code.status_from_severity(severity_code.UNKNOWN, alert.severity)
+            status = status_code.status_from_severity(app.config['DEFAULT_SEVERITY'], alert.severity)
         else:
             status = alert.status
 
@@ -559,7 +559,7 @@ class Mongo(object):
             "customer": alert.customer,
             "duplicateCount": 0,
             "repeat": False,
-            "previousSeverity": severity_code.UNKNOWN,
+            "previousSeverity": app.config['DEFAULT_SEVERITY'],
             "trendIndication": trend_indication,
             "receiveTime": now,
             "lastReceiveId": alert.id,

--- a/alerta/app/severity_code.py
+++ b/alerta/app/severity_code.py
@@ -6,16 +6,15 @@ http://tools.ietf.org/html/rfc5674
 http://www.itu.int/rec/T-REC-M.3100
 http://www.itu.int/rec/T-REC-X.736-199201-I
 
-           ITU Perceived Severity      syslog SEVERITY (Name)
-           Critical                    1 (Alert)
-           Major                       2 (Critical)
-           Minor                       3 (Error)
-           Warning                     4 (Warning)
-           Indeterminate               5 (Notice)
-           Cleared                     5 (Notice)
+Alarm Model State           ITU Perceived Severity      syslog SEVERITY (Name)
+      6                     Critical                    1 (Alert)
+      5                     Major                       2 (Critical)
+      4                     Minor                       3 (Error)
+      3                     Warning                     4 (Warning)
+      2                     Indeterminate               5 (Notice)
+      1                     Cleared                     5 (Notice)
 """
 from alerta.app import app
-from alerta.app import status_code
 
 # NOTE: The display text in single quotes can be changed depending on preference.
 # eg. CRITICAL = 'critical' or CRITICAL = 'CRITICAL'
@@ -36,8 +35,8 @@ UNKNOWN = 'unknown'
 NOT_VALID = 'notValid'
 
 MORE_SEVERE = 'moreSevere'
-LESS_SEVERE = 'lessSevere'
 NO_CHANGE = 'noChange'
+LESS_SEVERE = 'lessSevere'
 
 SEVERITY_MAP = app.config['SEVERITY_MAP']
 
@@ -93,23 +92,9 @@ def parse_severity(name):
 
 
 def trend(previous, current):
-    if previous == UNKNOWN:
-        previous = NORMAL  # assume normal for the purposes of calculating trend indication
     if name_to_code(previous) > name_to_code(current):
         return MORE_SEVERE
     elif name_to_code(previous) < name_to_code(current):
         return LESS_SEVERE
     else:
         return NO_CHANGE
-
-
-def status_from_severity(previous_severity, current_severity, current_status=status_code.UNKNOWN):
-    if current_severity in [DEBUG, TRACE]:
-        return current_status
-    if current_severity in [NORMAL, CLEARED, OK]:
-        return status_code.CLOSED
-    if current_status in [status_code.CLOSED, status_code.EXPIRED]:
-        return status_code.OPEN
-    if trend(previous_severity, current_severity) == MORE_SEVERE:
-        return status_code.OPEN
-    return current_status

--- a/alerta/app/status_code.py
+++ b/alerta/app/status_code.py
@@ -1,3 +1,6 @@
+
+from alerta.app import severity_code
+
 """
 Possible alert status codes.
 """
@@ -43,3 +46,13 @@ def parse_status(name):
             if name.lower() == st.lower():
                 return st
     return NOT_VALID
+
+
+def status_from_severity(previous_severity, current_severity, current_status=OPEN):
+    if current_severity in [severity_code.NORMAL, severity_code.CLEARED, severity_code.OK]:
+        return CLOSED
+    if current_status in [CLOSED, EXPIRED]:
+        return OPEN
+    if severity_code.trend(previous_severity, current_severity) == severity_code.MORE_SEVERE:
+        return OPEN
+    return current_status

--- a/alerta/settings.py
+++ b/alerta/settings.py
@@ -65,8 +65,9 @@ SEVERITY_MAP = {
     'informational': 6,
     'debug': 7,
     'trace': 8,
-    'unknown': 9  # default
+    'unknown': 9
 }
+DEFAULT_SEVERITY = 'indeterminate'
 
 BLACKOUT_DURATION = 3600  # default period = 1 hour
 

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -96,7 +96,7 @@ class AlertTestCase(unittest.TestCase):
         data = json.loads(response.data.decode('utf-8'))
         self.assertIn(alert_id, data['alert']['id'])
         self.assertEqual(data['alert']['duplicateCount'], 1)
-        self.assertEqual(data['alert']['previousSeverity'], 'unknown')
+        self.assertEqual(data['alert']['previousSeverity'], app.config['DEFAULT_SEVERITY'])
         self.assertEqual(data['alert']['trendIndication'], 'moreSevere')
 
         # correlate alert (same event, diff sev)


### PR DESCRIPTION
Setting the default severity to `indeterminate` not `unknown` will achieve the same result as #266 in a more straight-forward way. To revert to the old behaviour (of previously unknown severity alerts being "moreSevere" instead of "noChange", for example) then just set `DEFAULT_SEVERITY = 'unknown'` in `alertad.conf`.