### PR TITLE
Add a method to detect flapping alerts

### DIFF
--- a/alerta/app/exceptions.py
+++ b/alerta/app/exceptions.py
@@ -1,0 +1,15 @@
+
+class AlertaException(IOError):
+    pass
+
+class RejectException(AlertaException):
+    """The alert was rejected because the format did not meet the required policy."""
+    pass
+
+class RateLimit(AlertaException):
+    """Too many alerts have been received for a resource or from an origin."""
+    pass
+
+class BlackoutPeriod(AlertaException):
+    """Alert was not processed becauese it was sent during a blackout period."""
+    pass

--- a/alerta/app/webhooks/views.py
+++ b/alerta/app/webhooks/views.py
@@ -17,7 +17,7 @@ from alerta.app.auth import auth_required
 from alerta.app.metrics import Timer
 from alerta.app.utils import absolute_url, process_alert, add_remote_ip
 from alerta.app.alert import Alert
-from alerta.plugins import RejectException
+from alerta.app.exceptions import RejectException
 
 LOG = app.logger
 

--- a/alerta/plugins/__init__.py
+++ b/alerta/plugins/__init__.py
@@ -10,10 +10,6 @@ from alerta.app import app
 LOG = logging.getLogger('alerta.plugins')
 
 
-class RejectException(Exception):
-    """The alert was rejected because the format did not meet the required policy."""
-
-
 @add_metaclass(abc.ABCMeta)
 class PluginBase(object):
 

--- a/alerta/plugins/reject.py
+++ b/alerta/plugins/reject.py
@@ -2,7 +2,8 @@ import re
 import logging
 
 from alerta.app import app
-from alerta.plugins import PluginBase, RejectException
+from alerta.app.exceptions import RejectException
+from alerta.plugins import PluginBase
 
 LOG = logging.getLogger('alerta.plugins.reject')
 


### PR DESCRIPTION
These new features (ie. `is_flapping()` detection and `RateLimit` exception) are available for use in plugins as what actions should be taken if an alert is detected to be flapping is implementation dependent.

For example, it's possible to change the alert status, set the severity, set a 'flapping' boolean in the attributes or reject the alert with 429 status code.

https://tools.ietf.org/html/rfc6585#page-3

**Example Plugin**

```python
import logging

from alerta.app import db
from alerta.app.exceptions import RateLimit
from alerta.plugins import PluginBase

LOG = logging.getLogger('alerta.plugins.transient')

FLAPPING_COUNT = 2
FLAPPING_WINDOW = 120  # seconds

class TransientAlert(PluginBase):

    def pre_receive(self, alert):

        LOG.info("Detecting transient alerts...")
        if db.is_flapping(alert, window=FLAPPING_WINDOW, count=FLAPPING_COUNT):
            alert.severity = 'indeterminate'
            alert.attributes['flapping'] = True
            # uncomment following line to stop alerts from being processed
            # raise RateLimit("Flapping alert received more than %s times in %s seconds" % (FLAPPING_COUNT, FLAPPING_WINDOW))
        else:
            alert.attributes['flapping'] = False

        return alert

    def post_receive(self, alert):
        return

    def status_change(self, alert, status, text):
        return
```