### PR TITLE
Docker MongoDB has leading slash on MONGO_NAME

### DIFF
--- a/alerta/app/database/mongo.py
+++ b/alerta/app/database/mongo.py
@@ -45,7 +45,7 @@ class Database(object):
 
         if 'MONGO_PORT' in os.environ and 'tcp://' in os.environ['MONGO_PORT']:  # Docker
             host, port = os.environ['MONGO_PORT'][6:].split(':')
-            mongo_uri = 'mongodb://%s:%s/%s' % (host, port, os.environ['MONGO_NAME'])
+            mongo_uri = 'mongodb://%s:%s%s' % (host, port, os.environ['MONGO_NAME'])
 
         mongo_uri = mongo_uri or app.config['MONGO_URI']  # use app config if no env var overrides
 


### PR DESCRIPTION
Example Docker Image environment variables...
```
$ docker run --link alerta-db:mongo -e AUTH_REQUIRED=$AUTH_REQUIRED -e PROVIDER=$PROVIDER -e CLIENT_ID=$CLIENT_ID -e CLIENT_SECRET=$CLIENT_SECRET -e ALLOWED_EMAIL_DOMAIN=$ALLOWED_EMAIL_DOMAIN -t -i -p 49901:80 alerta/alerta-web env
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOSTNAME=d3d51074849d
TERM=xterm
MONGO_PORT=tcp://172.17.0.2:27017
MONGO_PORT_27017_TCP=tcp://172.17.0.2:27017
MONGO_PORT_27017_TCP_ADDR=172.17.0.2
MONGO_PORT_27017_TCP_PORT=27017
MONGO_PORT_27017_TCP_PROTO=tcp
MONGO_NAME=/fervent_payne/mongo
MONGO_ENV_no_proxy=*.local, 169.254/16
MONGO_ENV_GOSU_VERSION=1.7
MONGO_ENV_MONGO_MAJOR=3.4
MONGO_ENV_MONGO_VERSION=3.4.0
MONGO_ENV_MONGO_PACKAGE=mongodb-org
AUTH_REQUIRED=True
PROVIDER=google
CLIENT_ID=
CLIENT_SECRET=
ALLOWED_EMAIL_DOMAIN=example.com
no_proxy=*.local, 169.254/16
ALERTA_SVR_CONF_FILE=/alertad.conf
BASE_URL=/api
ADMIN_USERS=not-set
CUSTOMER_VIEWS=False
ALLOWED_GITHUB_ORGS=*
GITLAB_URL=not-set
ALLOWED_GITLAB_GROUPS=*
PLUGINS=reject
ORIGIN_BLACKLIST=not-set
ALLOWED_ENVIRONMENTS=Production,Development
HOME=/root
```