### PR TITLE
Added a Riemann webhook

### DIFF
--- a/alerta/app/webhooks/views.py
+++ b/alerta/app/webhooks/views.py
@@ -745,7 +745,6 @@ def parse_riemann(alert):
         event=alert['service'],
         environment=alert.get('environment', 'Production'),
         severity=alert.get('state', 'unknown'),
-        status=alert.get('state', 'unknown'),
         service=[alert['service']],
         group=alert.get('group', 'Performance'),
         text=alert.get('description', None),

--- a/alerta/app/webhooks/views.py
+++ b/alerta/app/webhooks/views.py
@@ -736,3 +736,57 @@ def telegram():
         return jsonify(status="ok")
     else:
         return jsonify(status="error", message="no callback_query in Telegram message"), 400
+
+
+def parse_riemann(alert):
+
+    return Alert(
+        resource='%s-%s' % (alert['host'], alert['service']),
+        event=alert['service'],
+        environment=alert.get('environment', 'Production'),
+        severity=alert.get('state', 'unknown'),
+        status=alert.get('state', 'unknown'),
+        service=[alert['service']],
+        group=alert.get('group', 'Performance'),
+        text=alert.get('description', None),
+        value=alert.get('metric', None),
+        tags=alert.get('tags', None),
+        origin='Riemann',
+        raw_data=alert
+    )
+
+
+@app.route('/webhooks/riemann', methods=['OPTIONS', 'POST'])
+@cross_origin()
+@auth_required
+def riemann():
+
+    hook_started = webhook_timer.start_timer()
+    try:
+        incomingAlert = parse_riemann(request.json)
+    except ValueError as e:
+        webhook_timer.stop_timer(hook_started)
+        return jsonify(status="error", message=str(e)), 400
+
+    if g.get('customer', None):
+        incomingAlert.customer = g.get('customer')
+
+    add_remote_ip(request, incomingAlert)
+
+    try:
+        alert = process_alert(incomingAlert)
+    except RejectException as e:
+        webhook_timer.stop_timer(hook_started)
+        return jsonify(status="error", message=str(e)), 403
+    except Exception as e:
+        webhook_timer.stop_timer(hook_started)
+        return jsonify(status="error", message=str(e)), 500
+
+    webhook_timer.stop_timer(hook_started)
+
+    if alert:
+        body = alert.get_body()
+        body['href'] = absolute_url('/alert/' + alert.id)
+        return jsonify(status="ok", id=alert.id, alert=body), 201, {'Location': body['href']}
+    else:
+        return jsonify(status="error", message="insert or update of Riemann alert failed"), 500

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -313,7 +313,6 @@ class WebhooksTestCase(unittest.TestCase):
         data = json.loads(response.data.decode('utf-8'))
         self.assertEqual(data['alert']['resource'], 'hostbob-servicejane')
         self.assertEqual(data['alert']['event'], 'servicejane')
-        self.assertEqual(data['alert']['status'], 'ok')
         self.assertEqual(data['alert']['severity'], 'ok')
         self.assertEqual(data['alert']['text'], 'This is a description')
         self.assertEqual(data['alert']['value'], 1)

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -116,6 +116,16 @@ class WebhooksTestCase(unittest.TestCase):
             }
         """
 
+        self.riemann_alert = """
+          {
+	        "host": "hostbob",
+	        "service": "servicejane",
+	        "state": "ok",
+	        "description": "This is a description",
+	        "metric": 1
+          }
+        """
+
         self.prometheus_alert = """
             {
                 "alerts": [
@@ -294,6 +304,19 @@ class WebhooksTestCase(unittest.TestCase):
         self.assertEqual(data['alert']['timeout'], 600)
         self.assertEqual(data['alert']['createTime'], "2016-08-01T10:27:08.008Z")
         self.assertEqual(data['alert']['attributes']['ip'], '192.168.1.1')
+
+    def test_riemann_webhook(self):
+
+        # create alert
+        response = self.app.post('/webhooks/riemann', data=self.riemann_alert, headers=self.headers)
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data['alert']['resource'], 'hostbob-servicejane')
+        self.assertEqual(data['alert']['event'], 'servicejane')
+        self.assertEqual(data['alert']['status'], 'ok')
+        self.assertEqual(data['alert']['severity'], 'ok')
+        self.assertEqual(data['alert']['text'], 'This is a description')
+        self.assertEqual(data['alert']['value'], 1)
 
     def test_grafana_webhook(self):
 


### PR DESCRIPTION
Adds a webhook for Riemann. Makes no assumptions about the format of
your Riemann events and consumes standard events. If events are
decorated with additional metadata: tags, environment, group, etc then
these will be used.

```python
return Alert(
        resource='%s-%s' % (alert['host'], alert['service']),
        event=alert['service'],
        environment=alert.get('environment', 'Production'),
        severity=alert.get('state', 'unknown'),
        status=alert.get('state', 'unknown'),
        service=[alert['service']],
        group=alert.get('group', 'Performance'),
        text=alert.get('description', None),
        value=alert.get('metric', None),
        tags=alert.get('tags', None),
        origin='Riemann',
        raw_data=alert
    )
```

Added a test too.