### PR TITLE
Setting default instance for Prometheus webhook

### DIFF
--- a/alerta/app/webhooks/views.py
+++ b/alerta/app/webhooks/views.py
@@ -340,7 +340,7 @@ def parse_prometheus(alert, external_url):
         annotations['moreInfo'] = '<a href="%s" target="_blank">Prometheus Graph</a>' % alert['generatorURL']
 
     return Alert(
-        resource=labels.pop('exported_instance', None) or labels.pop('instance'),
+        resource=labels.pop('exported_instance', None) or labels.pop('instance', 'NA'),
         event=labels.pop('alertname'),
         environment=labels.pop('environment', 'Production'),
         severity=severity,


### PR DESCRIPTION
Instance is associated with every scrape target in Prometheus. But label isn't necessary for all alerts and may not even make sense for some. For instance, while alerting on a service level rule.

I've currently set it to 'NA'. If there is a better alternative, please suggest.