### PR TITLE
Adds support for event field

### DIFF
--- a/alerta/app/webhooks/views.py
+++ b/alerta/app/webhooks/views.py
@@ -744,7 +744,7 @@ def parse_riemann(alert):
 
     return Alert(
         resource='%s-%s' % (alert['host'], alert['service']),
-        event=alert['service'],
+        event=alert.get('event', alert['service']),
         environment=alert.get('environment', 'Production'),
         severity=alert.get('state', 'unknown'),
         service=[alert['service']],


### PR DESCRIPTION
Couple of folks gave me feedback that they set an event field in
Riemann when sending to Alerta and other destinations. The current
webhook discards this potential field and uses service instead. This
changes the behavior so that if the event field exists it is used
otherwise it defaults to service.