### PR TITLE
Use '*' to allow user role to see all customer

### DIFF
--- a/alerta/app/auth.py
+++ b/alerta/app/auth.py
@@ -180,6 +180,8 @@ def customer_match(user, groups):
     else:
         match = db.get_customer_by_match([user] + groups)
         if match:
+            if match == '*':
+                return None
             return match
         else:
             raise NoCustomerMatch


### PR DESCRIPTION
Currently only admins can see all customers. This change will allow setting customer as "*" so that a user role may see all customers, but still not have admin rights.

In the example below the "noc@foo.com" user will be able to see all customer alerts but "user@foo.com" will only be able to see alerts for customer "Foo".

<img width="1025" alt="screen shot 2017-06-07 at 11 49 58" src="https://user-images.githubusercontent.com/615057/26874922-7f5a050c-4b77-11e7-9a49-6f5461884815.png">
