### PR TITLE
Fix Stackdriver webhook

### DIFF
--- a/alerta/app/webhooks/views.py
+++ b/alerta/app/webhooks/views.py
@@ -433,7 +433,7 @@ def parse_stackdriver(notification):
         status = None
         create_time = None
 
-    return state, Alert(
+    return Alert(
         resource=incident['resource_name'],
         event=incident['condition_name'],
         environment='Production',
@@ -461,7 +461,7 @@ def stackdriver():
 
     hook_started = webhook_timer.start_timer()
     try:
-        incomingAlert = parse_stackdriver(request.json)
+        incomingAlert = parse_stackdriver(request.get_json(force=True))
     except ValueError as e:
         webhook_timer.stop_timer(hook_started)
         return jsonify(status="error", message=str(e)), 400


### PR DESCRIPTION
This commit fixes two minor but breaking issues with the stackdriver webhook view:
1. The parse_stackdriver method was returning a tuple of a state (string) and an Alert,
where calling code was expecting it to return only an Alert.
2. The old code assumed that Stackdriver was setting the header
"Content-Type: application/json". Stackdriver should indeed set this, but
in practice it doesn't, so using request.get_json(force=True)
instead of request.json is an easy workaround.