### PR TITLE
Deprecate roles for scopes & permissions

### DIFF
--- a/alerta/app/auth.py
+++ b/alerta/app/auth.py
@@ -221,7 +221,7 @@ def login():
     else:
         customer = None
 
-    token = create_token(user['id'], user['name'], email, provider='basic', customer=customer, scopes=scopes(email, groups=[domain]))
+    token = create_token(user['id'], user['name'], email, provider='basic', customer=customer, scopes=scopes(email, groups=[user['role']]))
     return jsonify(token=token)
 
 
@@ -258,7 +258,7 @@ def signup():
 
     if app.config['CUSTOMER_VIEWS']:
         try:
-            customer = customer_match(email, groups=[role])
+            customer = customer_match(email, groups=[domain])
         except NoCustomerMatch:
             return jsonify(status="error", message="No customer lookup defined for user domain '%s'" % domain), 403
     else:
@@ -398,7 +398,7 @@ def saml_response_from_idp():
     else:
         customer = None
 
-    token = create_token(email, name, email, provider='saml2', customer=customer, role=role(email, groups=groups))
+    token = create_token(email, name, email, provider='saml2', customer=customer, scopes=scopes(email, groups=groups))
     return _make_response({'status': 'ok', 'token': token}, 200)
 
 

--- a/alerta/app/auth.py
+++ b/alerta/app/auth.py
@@ -16,6 +16,7 @@ from flask_cors import cross_origin
 from jwt import DecodeError, ExpiredSignature, InvalidAudience
 from base64 import urlsafe_b64decode
 from uuid import uuid4
+
 try:
     import saml2
     import saml2.entity
@@ -318,98 +319,6 @@ def verify_email(hash):
         return render_template('auth/verify_failed.html')
 
 
-if 'SAML2_CONFIG' in app.config:
-    spConfig = saml2.config.Config()
-    saml2_config_default = {
-        'entityid': absolute_url(),
-        'service': {
-            'sp': {
-                'endpoints': {
-                    'assertion_consumer_service': [
-                        (absolute_url('/auth/saml'), saml2.BINDING_HTTP_POST)
-                    ]
-                }
-            }
-        }
-    }
-    spConfig.load(deepmerge(saml2_config_default, app.config['SAML2_CONFIG']))
-    saml_client = saml2.client.Saml2Client(config=spConfig)
-
-
-@app.route('/auth/saml', methods=['GET'])
-def saml_redirect_to_idp():
-    relay_state = None if request.args.get('usePostMessage') is None else 'usePostMessage'
-    (session_id, result) = saml_client.prepare_for_authenticate(relay_state=relay_state)
-    return make_response('', 302, result['headers'])
-
-
-@app.route('/auth/saml', methods=['OPTIONS', 'POST'])
-@cross_origin(supports_credentials=True)
-def saml_response_from_idp():
-    def _make_response(resp_obj, resp_code):
-        if 'usePostMessage' in request.form.get('RelayState', '') and 'text/html' in request.headers.get('Accept', ''):
-            origins = app.config.get('CORS_ORIGINS', [])
-            response = make_response(
-                '''<!DOCTYPE html>
-                    <html lang="en">
-                        <head>
-                            <meta charset="UTF-8">
-                            <title>Authenticating...</title>
-                            <script type="application/javascript">
-                                var origins = {origins};
-                                // in case when API and WebUI are on the same origin
-                                if (origins.indexOf(window.location.origin) < 0)
-                                    origins.push(window.location.origin);
-                                // only one will succeed
-                                origins.forEach(origin => window.opener.postMessage({msg_data}, origin));
-                                window.close();
-                            </script>
-                        </head>
-                        <body></body>
-                    </html>'''.format(msg_data=json.dumps(resp_obj), origins=json.dumps(origins)),
-                resp_code
-            )
-            response.headers['Content-Type'] = 'text/html'
-            return response
-        else:
-            return jsonify(**resp_obj), resp_code
-
-    authn_response = saml_client.parse_authn_request_response(
-        request.form['SAMLResponse'],
-        saml2.entity.BINDING_HTTP_POST
-    )
-    identity = authn_response.get_identity()
-    email = identity['emailAddress'][0]
-    name = (app.config.get('SAML2_USER_NAME_FORMAT', '{givenName} {surname}')).format(**dict(map(lambda x: (x[0], x[1][0]), identity.items())))
-
-    groups = identity.get('groups', [])
-    if app.config['AUTH_REQUIRED'] and not ('*' in app.config['ALLOWED_SAML2_GROUPS']
-            or set(app.config['ALLOWED_SAML2_GROUPS']).intersection(set(groups))):
-        return _make_response({'status': 'error', 'message': 'User {} is not authorized'.format(email)}, 403)
-
-    if app.config['CUSTOMER_VIEWS']:
-        try:
-            customer = customer_match(email, groups=[email.split('@')[1]])
-        except NoCustomerMatch:
-            return _make_response(
-                {'status': 'error', 'message': 'No customer lookup defined for user %s' % email},
-                403
-            )
-    else:
-        customer = None
-
-    token = create_token(email, name, email, provider='saml2', customer=customer, scopes=scopes(email, groups=groups))
-    return _make_response({'status': 'ok', 'token': token}, 200)
-
-
-@app.route('/auth/saml/metadata.xml', methods=['GET'])
-def saml_metadata():
-    edesc = saml2.metadata.entity_descriptor(spConfig)
-    response = make_response(str(edesc))
-    response.headers['Content-Type'] = 'text/xml; charset=utf-8'
-    return response
-
-
 @app.route('/auth/google', methods=['OPTIONS', 'POST'])
 @cross_origin(supports_credentials=True)
 def google():
@@ -604,6 +513,98 @@ def keycloak():
 
     token = create_token(profile['sub'], profile['name'], login, provider='keycloak', customer=customer, scopes=scopes(login, groups=[]))
     return jsonify(token=token)
+
+
+if 'SAML2_CONFIG' in app.config:
+    spConfig = saml2.config.Config()
+    saml2_config_default = {
+        'entityid': absolute_url(),
+        'service': {
+            'sp': {
+                'endpoints': {
+                    'assertion_consumer_service': [
+                        (absolute_url('/auth/saml'), saml2.BINDING_HTTP_POST)
+                    ]
+                }
+            }
+        }
+    }
+    spConfig.load(deepmerge(saml2_config_default, app.config['SAML2_CONFIG']))
+    saml_client = saml2.client.Saml2Client(config=spConfig)
+
+
+@app.route('/auth/saml', methods=['GET'])
+def saml_redirect_to_idp():
+    relay_state = None if request.args.get('usePostMessage') is None else 'usePostMessage'
+    (session_id, result) = saml_client.prepare_for_authenticate(relay_state=relay_state)
+    return make_response('', 302, result['headers'])
+
+
+@app.route('/auth/saml', methods=['OPTIONS', 'POST'])
+@cross_origin(supports_credentials=True)
+def saml_response_from_idp():
+    def _make_response(resp_obj, resp_code):
+        if 'usePostMessage' in request.form.get('RelayState', '') and 'text/html' in request.headers.get('Accept', ''):
+            origins = app.config.get('CORS_ORIGINS', [])
+            response = make_response(
+                '''<!DOCTYPE html>
+                    <html lang="en">
+                        <head>
+                            <meta charset="UTF-8">
+                            <title>Authenticating...</title>
+                            <script type="application/javascript">
+                                var origins = {origins};
+                                // in case when API and WebUI are on the same origin
+                                if (origins.indexOf(window.location.origin) < 0)
+                                    origins.push(window.location.origin);
+                                // only one will succeed
+                                origins.forEach(origin => window.opener.postMessage({msg_data}, origin));
+                                window.close();
+                            </script>
+                        </head>
+                        <body></body>
+                    </html>'''.format(msg_data=json.dumps(resp_obj), origins=json.dumps(origins)),
+                resp_code
+            )
+            response.headers['Content-Type'] = 'text/html'
+            return response
+        else:
+            return jsonify(**resp_obj), resp_code
+
+    authn_response = saml_client.parse_authn_request_response(
+        request.form['SAMLResponse'],
+        saml2.entity.BINDING_HTTP_POST
+    )
+    identity = authn_response.get_identity()
+    email = identity['emailAddress'][0]
+    name = (app.config.get('SAML2_USER_NAME_FORMAT', '{givenName} {surname}')).format(**dict(map(lambda x: (x[0], x[1][0]), identity.items())))
+
+    groups = identity.get('groups', [])
+    if app.config['AUTH_REQUIRED'] and not ('*' in app.config['ALLOWED_SAML2_GROUPS']
+            or set(app.config['ALLOWED_SAML2_GROUPS']).intersection(set(groups))):
+        return _make_response({'status': 'error', 'message': 'User {} is not authorized'.format(email)}, 403)
+
+    if app.config['CUSTOMER_VIEWS']:
+        try:
+            customer = customer_match(email, groups=[email.split('@')[1]])
+        except NoCustomerMatch:
+            return _make_response(
+                {'status': 'error', 'message': 'No customer lookup defined for user %s' % email},
+                403
+            )
+    else:
+        customer = None
+
+    token = create_token(email, name, email, provider='saml2', customer=customer, scopes=scopes(email, groups=groups))
+    return _make_response({'status': 'ok', 'token': token}, 200)
+
+
+@app.route('/auth/saml/metadata.xml', methods=['GET'])
+def saml_metadata():
+    edesc = saml2.metadata.entity_descriptor(spConfig)
+    response = make_response(str(edesc))
+    response.headers['Content-Type'] = 'text/xml; charset=utf-8'
+    return response
 
 
 @app.route('/userinfo', methods=['OPTIONS', 'GET'])

--- a/alerta/app/auth.py
+++ b/alerta/app/auth.py
@@ -235,9 +235,10 @@ def signup():
         domain = email.split('@')[1]
         password = request.json["password"]
         provider = request.json.get("provider", "basic")
+        role = 'admin' if email in app.config.get('ADMIN_USERS') else 'user'
         text = request.json.get("text", "")
         try:
-            user = db.create_user(name, email, password, provider, text, email_verified=False)
+            user = db.create_user(name, email, password, provider, role, text, email_verified=False)
         except Exception as e:
             return jsonify(status="error", message=str(e)), 500
     else:
@@ -257,13 +258,13 @@ def signup():
 
     if app.config['CUSTOMER_VIEWS']:
         try:
-            customer = customer_match(email, groups=[domain])
+            customer = customer_match(email, groups=[role])
         except NoCustomerMatch:
             return jsonify(status="error", message="No customer lookup defined for user domain '%s'" % domain), 403
     else:
         customer = None
 
-    token = create_token(user['id'], user['name'], email, provider, customer, scopes=scopes(email, groups=[domain]))
+    token = create_token(user['id'], user['name'], email, provider, customer, scopes=scopes(email, groups=[role]))
     return jsonify(token=token)
 
 

--- a/alerta/app/database/mongo.py
+++ b/alerta/app/database/mongo.py
@@ -1213,7 +1213,6 @@ class Database(object):
     def get_users(self, query=None, password=False):
 
         users = list()
-
         for user in self.db.users.find(query):
             login = user.get('login', None) or user.get('email', None)  # for backwards compatibility
             u = {
@@ -1222,6 +1221,7 @@ class Database(object):
                 "login": login,
                 "createTime": user['createTime'],
                 "provider": user['provider'],
+                "role": 'admin' if login in app.config.get('ADMIN_USERS') else user.get('role', 'user'),
                 "text": user.get('text', ""),
                 "email_verified": user.get('email_verified', False)
             }
@@ -1239,7 +1239,7 @@ class Database(object):
         if login:
             return bool(self.db.users.find_one({"login": login}))
 
-    def update_user(self, id, name=None, login=None, password=None, provider=None, text=None, email_verified=None):
+    def update_user(self, id, name=None, login=None, password=None, provider=None, role=None, text=None, email_verified=None):
 
         if not self.is_user_valid(id=id):
             return
@@ -1253,6 +1253,8 @@ class Database(object):
             data['password'] = bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt(prefix=b'2a')).decode('utf-8')
         if provider:
             data['provider'] = provider
+        if role:
+            data['role'] = role
         if text:
             data['text'] = text
         if email_verified:
@@ -1263,7 +1265,7 @@ class Database(object):
         if response.matched_count > 0:
             return id
 
-    def create_user(self, name, login, password=None, provider="", text="", email_verified=False):
+    def create_user(self, name, login, password=None, provider="basic", role="user", text="", email_verified=False):
 
         if self.is_user_valid(login=login):
             return
@@ -1274,6 +1276,7 @@ class Database(object):
             "login": login,
             "createTime": datetime.datetime.utcnow(),
             "provider": provider,
+            "role": role,
             "text": text,
             "email_verified": email_verified
         }
@@ -1339,19 +1342,18 @@ class Database(object):
         return True if response.deleted_count == 1 else False
 
     def get_scopes_by_match(self, matches):
-        if matches[0] in app.config['ADMIN_USERS']:
-            return ['admin', 'read', 'write']
 
         if isinstance(matches, string_types):
             matches = [matches]
 
-        def find_scopes(match):
+        if matches[0] in app.config['ADMIN_USERS']:
+            return ['admin', 'read', 'write']
+
+        for match in matches:
             response = self.db.scopes.find_one({"match": match}, projection={"scopes": 1, "_id": 0})
             if response:
                 return response['scopes']
-
-        results = [find_scopes(m) for m in matches]
-        return next((r for r in results if r is not None), app.config['USER_DEFAULT_SCOPES'])
+        return app.config['USER_DEFAULT_SCOPES']
 
     def create_customer(self, customer, match):
 
@@ -1372,13 +1374,11 @@ class Database(object):
         if isinstance(matches, string_types):
             matches = [matches]
 
-        def find_customer(match):
+        for match in matches:
             response = self.db.customers.find_one({"match": match}, projection={"customer": 1, "_id": 0})
             if response:
                 return response['customer']
-
-        results = [find_customer(m) for m in matches]
-        return next((r for r in results if r is not None), None)
+        return
 
     def get_customers(self, query=None):
 

--- a/alerta/app/views.py
+++ b/alerta/app/views.py
@@ -829,13 +829,14 @@ def create_user():
         login = request.json["login"]
         password = request.json["password"]
         provider = request.json.get("provider", "basic")
+        role = request.json.get("role", "user")
         text = request.json.get("text", "")
         email_verified = request.json.get("email_verified", False)
     else:
         return jsonify(status="error", message="Must supply user 'name', 'login' and 'password' as parameters"), 400
 
     try:
-        user = db.create_user(name, login, password, provider, text, email_verified)
+        user = db.create_user(name, login, password, provider, role, text, email_verified)
     except Exception as e:
         return jsonify(status="error", message=str(e)), 500
 
@@ -856,6 +857,7 @@ def update_user(user):
         login = request.json.get('login', None)
         password = request.json.get('password', None)
         provider = request.json.get('provider', None)
+        role = request.json.get('role', None)
         text = request.json.get('text', None)
         email_verified = request.json.get('email_verified', None)
     else:
@@ -865,7 +867,7 @@ def update_user(user):
         return jsonify(status="error", message="Can only change the password for Basic Auth users."), 400
 
     try:
-        user = db.update_user(user, name, login, password, provider, text, email_verified)
+        user = db.update_user(user, name, login, password, provider, role, text, email_verified)
     except Exception as e:
         return jsonify(status="error", message=str(e)), 500
     


### PR DESCRIPTION
Following #367 this deprecates the use of "role" for all auth methods except basic auth.