### PR TITLE
change mongclient serverselectiontimeoutms

### DIFF
--- a/alerta/app/database/mongo.py
+++ b/alerta/app/database/mongo.py
@@ -67,7 +67,7 @@ class Database(object):
                 'ssl_cert_reqs': ssl.CERT_REQUIRED }
 
         try:
-            self.connection = MongoClient(mongo_uri, serverSelectionTimeoutMS=2000, connect=False, **ssl_args)
+            self.connection = MongoClient(mongo_uri, serverselectiontimeoutms=2000, connect=False, **ssl_args)
         except Exception as e:
             LOG.error('MongoDB Client: %s : %s', mongo_uri, e)
             sys.exit(1)


### PR DESCRIPTION
This parameter serverSelectionTimeoutMS seems to be wrong, 
2017-07-24 11:21:44,104 - alerta[16327]: ERROR - MongoDB Client: mongodb://localhost:27017/monitoring : Unknown option serverSelectionTimeoutMS [in /usr/lib/python2.7/site-packages/alerta_server-0.1.0-py2.7.egg/alerta/app/database/mongo.py:70]