### PR TITLE
RBAC does not allow direct assignment of perms to users

### DIFF
--- a/alerta/app/auth.py
+++ b/alerta/app/auth.py
@@ -163,7 +163,7 @@ def permission(scope):
 
 
 def scopes(user, groups):
-    return db.get_scopes_by_match([user] + groups)
+    return db.get_scopes_by_match(user, groups)
 
 
 class NoCustomerMatch(KeyError):
@@ -511,7 +511,7 @@ def keycloak():
     else:
         customer = None
 
-    token = create_token(profile['sub'], profile['name'], login, provider='keycloak', customer=customer, scopes=scopes(login, groups=[]))
+    token = create_token(profile['sub'], profile['name'], login, provider='keycloak', customer=customer, scopes=scopes(login, groups=roles))
     return jsonify(token=token)
 
 

--- a/alerta/app/database/mongo.py
+++ b/alerta/app/database/mongo.py
@@ -1355,12 +1355,9 @@ class Database(object):
             data['id'] = data.pop('_id')
             return data
 
-    def get_scopes_by_match(self, matches):
+    def get_scopes_by_match(self, login, matches):
 
-        if isinstance(matches, string_types):
-            matches = [matches]
-
-        if matches[0] in app.config['ADMIN_USERS']:
+        if login in app.config['ADMIN_USERS']:
             return ['admin', 'read', 'write']
 
         scopes = list()


### PR DESCRIPTION
> The ability to tie permissions directly to users in a group-based mechanism can be regarded as a "loophole" that makes it difficult to control user-permission relationships. RBAC requires all access through roles, and permissions are connected only to roles, not directly to users.

See http://csrc.nist.gov/groups/SNS/rbac/faq.html