### PR TITLE
auth/google: fallback to email if profile['name'] not available

### DIFF
--- a/alerta/auth/google.py
+++ b/alerta/auth/google.py
@@ -47,6 +47,6 @@ def google():
 
     customer = get_customer(id_token.email, groups=[domain])
 
-    token = create_token(id_token.subject, profile['name'], id_token.email, provider='google', customer=customer,
+    token = create_token(id_token.subject, 'name' in profile and profile['name'] or id_token.email, id_token.email, provider='google', customer=customer,
                          orgs=[domain], email=id_token.email, email_verified=id_token.email_verified)
     return jsonify(token=token.tokenize)

--- a/alerta/auth/google.py
+++ b/alerta/auth/google.py
@@ -47,6 +47,7 @@ def google():
 
     customer = get_customer(id_token.email, groups=[domain])
 
-    token = create_token(id_token.subject, 'name' in profile and profile['name'] or id_token.email, id_token.email, provider='google', customer=customer,
+    username = profile.get('name', id_token.email.split('@')[0])
+    token = create_token(id_token.subject, username, id_token.email, provider='google', customer=customer,
                          orgs=[domain], email=id_token.email, email_verified=id_token.email_verified)
     return jsonify(token=token.tokenize)

--- a/alerta/auth/google.py
+++ b/alerta/auth/google.py
@@ -47,7 +47,7 @@ def google():
 
     customer = get_customer(id_token.email, groups=[domain])
 
-    username = profile.get('name', id_token.email.split('@')[0])
-    token = create_token(id_token.subject, username, id_token.email, provider='google', customer=customer,
+    name = profile.get('name', id_token.email.split('@')[0])
+    token = create_token(id_token.subject, name, id_token.email, provider='google', customer=customer,
                          orgs=[domain], email=id_token.email, email_verified=id_token.email_verified)
     return jsonify(token=token.tokenize)


### PR DESCRIPTION
Sometimes, `profile['name']` is not available (at least, in our company settings). This patch uses email as a fallback value. We may have better fallbacks (e.g, by removing domain from email,...). This PR is an idea. Please let me know if I can help.

NB: The fallback code is from https://github.com/redlotus. I prefer Ruby way 🍡 